### PR TITLE
Allow custom loggers to use with_context

### DIFF
--- a/lib/shoryuken/logging.rb
+++ b/lib/shoryuken/logging.rb
@@ -16,10 +16,19 @@ module Shoryuken
     end
 
     def self.with_context(msg)
-      Thread.current[:shoryuken_context] = msg
+      if logger.respond_to?(:add_context)
+        logger.add_context(msg)
+      else
+        Thread.current[:shoryuken_context] ||= []
+        Thread.current[:shoryuken_context] << msg
+      end
       yield
     ensure
-      Thread.current[:shoryuken_context] = nil
+      if logger.respond_to?(:clear_context!)
+        logger.clear_context!
+      else
+        Thread.current[:shoryuken_context] = nil
+      end
     end
 
     def self.initialize_logger(log_target = STDOUT)

--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -22,7 +22,7 @@ module Shoryuken
         end
       end
     rescue Exception => ex
-      logger.error { "Processor failed: Exception: #{ex.name} with message:#{ex.message}" }
+      logger.error { "Processor failed: Exception: #{ex.class.name} with message:#{ex.message}" }
       logger.error { ex.backtrace.join("\n") } unless ex.backtrace.nil?
 
       raise

--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -22,7 +22,7 @@ module Shoryuken
         end
       end
     rescue Exception => ex
-      logger.error { "Processor failed: #{ex.message}" }
+      logger.error { "Processor failed: Exception: #{ex.name} with message:#{ex.message}" }
       logger.error { ex.backtrace.join("\n") } unless ex.backtrace.nil?
 
       raise

--- a/spec/shoryuken/logging_spec.rb
+++ b/spec/shoryuken/logging_spec.rb
@@ -1,0 +1,98 @@
+require "spec_helper"
+
+RSpec.describe Shoryuken::Logging do
+  class self::MyLogger < Logger
+    def initialize(output)
+      super(output)
+      @context = []
+    end
+
+    def info(msg)
+      super(@context.join(" ") + " " + msg)
+    end
+
+    def add_context(msg)
+      @context << msg
+    end
+
+    def clear_context
+      @context = nil
+    end
+  end
+  let(:output) do
+    StringIO.new
+  end
+  context ".with_context" do
+    context "with customer logger" do
+      let(:formatter) do
+        double('my_formatter')
+      end
+      let(:custom_logger) do
+        self.class::MyLogger.new(output)
+      end
+      before(:each) do
+        Shoryuken::Logging.logger = custom_logger
+      end
+      it "can attach context if logger implements #update_log_content" do
+        my_context = "my_context"
+        my_msg = "My log msg"
+        Shoryuken::Logging.with_context(my_context) do
+          custom_logger.info my_msg
+        end
+
+        output.rewind
+        msg = output.read
+        expect(msg).to include(my_context)
+        expect(my_msg).to include(my_msg)
+      end
+
+      it "cleans up via #clear_context" do
+        expect(custom_logger).to receive(:clear_context!)
+        Shoryuken::Logging.with_context("context") do
+          custom_logger.info "some msg"
+        end
+      end
+    end
+
+    context "built in logger" do
+      it "appends the context" do
+        my_context = "my_context"
+        my_msg = "My log msg"
+        Shoryuken::Logging.initialize_logger(output)
+        Shoryuken::Logging.with_context(my_context) do
+          Shoryuken::Logging.logger.info my_msg
+        end
+
+        output.rewind
+        msg = output.read
+        expect(msg).to include(my_context)
+        expect(my_msg).to include(my_msg)
+      end
+
+      it "lets you nest context" do
+        my_context = "my_context"
+        my_context2 = "aother context"
+        my_msg = "My log msg"
+        Shoryuken::Logging.initialize_logger(output)
+        Shoryuken::Logging.with_context(my_context) do
+          Shoryuken::Logging.with_context(my_context2) do
+            Shoryuken::Logging.logger.info my_msg
+          end
+        end
+
+        output.rewind
+        msg = output.read
+        expect(msg).to include(my_context)
+        expect(msg).to include(my_context2)
+        expect(my_msg).to include(my_msg)
+      end
+
+      it "cleans up" do
+        Shoryuken::Logging.with_context("anything") do
+          Shoryuken::Logging.logger.info "anything"
+        end
+        expect(Thread.current[:shoryuken_context]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to this change anyone who used a custom logger likely missed out
on anything set in Shoryuken::Logging.with_context.

This PR allows loggers who implement:

- #add_context
- #clear_context!

to take advantage of any context set via .with_context.

This PR also adds the ability to set nested context's, prior to this
only one context could be set.

Lastly, I added the exception class name raised in Shoryuken::Processor#process, we were
expecting to see logs for `ActiveJob::DeserializationError` but because
of some configuration issues this didn't happen.  I thought others would
also benefit from this since this is default behavior with ruby's built
in logger https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html#method-i-add