### PR TITLE
Improve config loader error messaging

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -43,11 +43,19 @@ module Shoryuken
 
       fail ArgumentError, "The supplied config file #{path} does not exist" unless File.exist?(path)
 
-      if (result = YAML.load(ERB.new(IO.read(path)).result))
+      if (result = load_config_file(path))
         result.deep_symbolize_keys
       else
         {}
       end
+    end
+
+    def load_config_file(path)
+      YAML.load(ERB.new(IO.read(path)).result)
+    rescue NameError => ex
+      fail(
+        "Rails and other constants not yet loaded. You can use ENV, or move your config to an initializer:\n#{ex.message}"
+      )
     end
 
     def initialize_logger


### PR DESCRIPTION
When a YAML config file references Rails or another constant, add recommended steps to the message.

Related: https://github.com/phstc/shoryuken/pull/200

```
shoryuken_1  | /srv/shoryuken/lib/shoryuken/environment_loader.rb:52:in `rescue in config_file_options': Rails and other constants not yet loaded. Try moving your config to an initializer, or using ENV instead: (RuntimeError)
shoryuken_1  | uninitialized constant Rails
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/environment_loader.rb:41:in `config_file_options'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/environment_loader.rb:37:in `initialize_options'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/environment_loader.rb:21:in `setup_options'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/environment_loader.rb:7:in `setup_options'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/runner.rb:31:in `run'
shoryuken_1  | 	from /srv/shoryuken/bin/shoryuken:42:in `start'
shoryuken_1  | 	from /opt/bundle/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
shoryuken_1  | 	from /opt/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
shoryuken_1  | 	from /opt/bundle/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
shoryuken_1  | 	from /opt/bundle/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
shoryuken_1  | 	from /srv/shoryuken/bin/shoryuken:53:in `<top (required)>'
shoryuken_1  | 	from /srv/bin/shoryuken:29:in `load'
shoryuken_1  | 	from /srv/bin/shoryuken:29:in `<main>'
shoryuken_1  | (erb):16:in `<main>': uninitialized constant Rails (NameError)
shoryuken_1  | 	from /usr/local/lib/ruby/2.7.0/erb.rb:905:in `eval'
shoryuken_1  | 	from /usr/local/lib/ruby/2.7.0/erb.rb:905:in `result'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/environment_loader.rb:46:in `config_file_options'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/environment_loader.rb:37:in `initialize_options'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/environment_loader.rb:21:in `setup_options'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/environment_loader.rb:7:in `setup_options'
shoryuken_1  | 	from /srv/shoryuken/lib/shoryuken/runner.rb:31:in `run'
shoryuken_1  | 	from /srv/shoryuken/bin/shoryuken:42:in `start'
shoryuken_1  | 	from /opt/bundle/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
shoryuken_1  | 	from /opt/bundle/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
shoryuken_1  | 	from /opt/bundle/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
shoryuken_1  | 	from /opt/bundle/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
shoryuken_1  | 	from /srv/shoryuken/bin/shoryuken:53:in `<top (required)>'
shoryuken_1  | 	from /srv/bin/shoryuken:29:in `load'
shoryuken_1  | 	from /srv/bin/shoryuken:29:in `<main>'
```