### PR TITLE
Add Rails reloading support

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -69,6 +69,8 @@ module Shoryuken
     :sqs_client=,
     :sqs_client_receive_message_opts,
     :sqs_client_receive_message_opts=,
+    :reloader,
+    :reloader=,
     :options,
     :logger,
     :register_worker,

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -70,6 +70,13 @@ module Shoryuken
             ::Rails.application.config.eager_load = true
           end
         end
+        ::Rails::Application.initializer 'shoryuken.set_reloader_hook' do |app|
+          Shoryuken.reloader = proc do |&block|
+            app.reloader.wrap do
+              block.call
+            end
+          end
+        end
         require 'shoryuken/extensions/active_job_adapter' if Shoryuken.active_job?
         require File.expand_path('config/environment.rb')
       end

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -15,7 +15,7 @@ module Shoryuken
     }.freeze
 
     attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout, :groups,
-                  :launcher_executor,
+                  :launcher_executor, :reloader,
                   :start_callback, :stop_callback, :worker_executor, :worker_registry
     attr_writer :default_worker_options, :sqs_client
     attr_reader :sqs_client_receive_message_opts
@@ -26,6 +26,7 @@ module Shoryuken
       self.active_job_queue_name_prefixing = false
       self.worker_executor = Worker::DefaultExecutor
       self.cache_visibility_timeout = false
+      self.reloader = proc { |&block| block.call }
       # this is needed for keeping backward compatibility
       @sqs_client_receive_message_opts ||= {}
     end

--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -14,11 +14,13 @@ module Shoryuken
     end
 
     def process
-      return logger.error { "No worker found for #{queue}" } unless worker
+      Shoryuken.reloader.call do
+        return logger.error { "No worker found for #{queue}" } unless worker
 
-      Shoryuken::Logging.with_context("#{worker_name(worker.class, sqs_msg, body)}/#{queue}/#{sqs_msg.message_id}") do
-        worker.class.server_middleware.invoke(worker, queue, sqs_msg, body) do
-          worker.perform(sqs_msg, body)
+        Shoryuken::Logging.with_context("#{worker_name(worker.class, sqs_msg, body)}/#{queue}/#{sqs_msg.message_id}") do
+          worker.class.server_middleware.invoke(worker, queue, sqs_msg, body) do
+            worker.perform(sqs_msg, body)
+          end
         end
       end
     rescue Exception => ex

--- a/spec/shoryuken/processor_spec.rb
+++ b/spec/shoryuken/processor_spec.rb
@@ -159,5 +159,24 @@ RSpec.describe Shoryuken::Processor do
         subject.process
       end
     end
+
+    context 'when specifying a reloader' do
+      before do
+        Shoryuken.reloader = proc do |_|
+          TestWorker.new.called
+        end
+      end
+
+      after do
+        Shoryuken.reloader = proc { |&block| block.call }
+      end
+
+      it 'wraps execution in reloader' do
+        expect_any_instance_of(TestWorker).to receive(:called)
+        expect_any_instance_of(TestWorker).to_not receive(:perform)
+
+        subject.process
+      end
+    end
   end
 end


### PR DESCRIPTION
This change adds explicit integration for Rails autoloading. Rails autoloading already partially worked in Shoryuken in that constants that weren't eager loaded were automatically autoloaded. Shoryuken, however, didn't respect `config.cache_classes`. This meant that once a constant was loaded by the Shoryuken process, it would never be unloaded and reloaded. If you changed the code in a worker class after Shoryuken had loaded it, the change would have no effect until you restarted the Shoryuken process.

The proposed change uses `Rails.application.reloader`, which takes care of safely reloading constants. This is the same technique employed by [active_job][0] and [sidekiq][1] and even explicitly documented in the [Rails guides][2]. The reloader takes the appropriate locks to ensure that no two threads ever simultaneously unload or reload constants. If the application developer modifies code in an autoloaded directory (including the implementation of workers themselves in `app/workers`), the changes will take effect the next time a job is processed.

[0]: https://github.com/rails/rails/blob/ab4ab090667e96c0e8a2623e33573ae06be14b54/activejob/lib/active_job/railtie.rb#L42-L44
[1]: https://github.com/mperham/sidekiq/blob/460ce532714444e186a60d49c9251b93909d4a58/lib/sidekiq/rails.rb#L13-L15
[2]: https://github.com/rails/rails/blob/ab4ab090667e96c0e8a2623e33573ae06be14b54/guides/source/threading_and_code_execution.md#reloader

## Breaking changes

This change probably warrants a major version bump. The reason for that is that if Shoryuken library code has any reference to objects that belong to autoloaded modules, it's quite easy to run into autoloading errors. If other people's apps are like my own, this is most likely to happen with custom middleware. This is an example from a Rails initializer:

```ruby
Shoryuken.configure_server do |config|
  config.server_middleware do |chain|
    chain.add MyCustomMiddleware
  end
end
```

Assume `MyCustomMiddleware` is defined in an autoloaded directory (basically anything under `app`, in addition to directories explicitly added to `config.autoload_paths`), and that the execution of `MyCustomMiddleware#call` has unqualified references to autoloaded constants. In this case, if Shoryuken tries to invoke that middleware after the application developer has triggered reloading (by modifying files in autoloaded directories), then autoloading will fail with `A copy of MyCustomMiddleware has been removed from the module tree but is still active!`. 

The fix is to ensure that Shoryuken library code never retains a reference to any object defined in autoloaded modules and whose code has references to autoloaded modules. In the example of custom middleware, the easiest solution is to just attach the middleware to workers instead of the global `server_middleware`. You can even do this in your base worker class.

```ruby
class ApplicationWorker
  include Shoryuken::Worker

  def self.inherited(klass)
    klass.server_middleware do |chain|
      chain.add MyCustomMiddleware
    end
  end
end
```

This works because the worker-specific middleware chain has a lifetime associated with the worker class. Once unloading happens, the old references to `MyCustomMiddleware` are unreachable by the Shoryuken process. When a new job comes in, Shoryuken autoloads the worker class, and the `inherited` block will run, constructing a new instance of the `MyCustomMiddleware` class through autoloading.

Users upgrading to a version of Shoryuken that includes this change can, in theory, alternatively just turn on `config.cache_classes` in their Shoryuken server process (even in development). The experience will be the same as before in that classes won't be reloaded, but it might be an easier upgrade path for some.

```ruby
Shoryuken.configure_server do
  Rails.application.configure do
    config.cache_classes = true
  end
end
```