### PR TITLE
Support use custom middleware for InlineExecutor

### DIFF
--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -94,7 +94,7 @@ module Shoryuken
     end
 
     def configure_server
-      yield self if server?
+      yield self if server? || inline_executor?
     end
 
     def server_middleware
@@ -159,9 +159,15 @@ module Shoryuken
       @active_job_queue_name_prefixing
     end
 
+    def inline_executor?
+      worker_executor == Worker::InlineExecutor
+    end
+
     private
 
     def default_server_middleware
+      return Middleware::Chain.new if inline_executor?
+
       Middleware::Chain.new do |m|
         m.add Middleware::Server::Timing
         m.add Middleware::Server::ExponentialBackoffRetry

--- a/lib/shoryuken/worker/inline_executor.rb
+++ b/lib/shoryuken/worker/inline_executor.rb
@@ -28,13 +28,16 @@ module Shoryuken
         private
 
         def call(worker_class, sqs_msg)
-          parsed_body = BodyParser.parse(worker_class, sqs_msg)
-          batch = worker_class.shoryuken_options_hash['batch']
-          args = batch ? [[sqs_msg], [parsed_body]] : [sqs_msg, parsed_body]
           worker = worker_class.new
           worker_class.server_middleware.invoke(worker, 'default', sqs_msg, sqs_msg.body) do
-            worker.perform(*args)
+            worker.perform(*perform_arguments(worker_class, sqs_msg))
           end
+        end
+
+        def perform_arguments(worker_class, sqs_msg)
+          parsed_body = BodyParser.parse(worker_class, sqs_msg)
+          batch = worker_class.shoryuken_options_hash['batch']
+          batch ? [[sqs_msg], [parsed_body]] : [sqs_msg, parsed_body]
         end
       end
     end

--- a/lib/shoryuken/worker/inline_executor.rb
+++ b/lib/shoryuken/worker/inline_executor.rb
@@ -31,7 +31,10 @@ module Shoryuken
           parsed_body = BodyParser.parse(worker_class, sqs_msg)
           batch = worker_class.shoryuken_options_hash['batch']
           args = batch ? [[sqs_msg], [parsed_body]] : [sqs_msg, parsed_body]
-          worker_class.new.perform(*args)
+          worker = worker_class.new
+          worker_class.server_middleware.invoke(worker, 'default', sqs_msg, sqs_msg.body) do
+            worker.perform(*args)
+          end
         end
       end
     end

--- a/spec/shoryuken/worker/inline_executor_spec.rb
+++ b/spec/shoryuken/worker/inline_executor_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 
 RSpec.describe Shoryuken::Worker::InlineExecutor do
   before do
+    # Reset values on memory to set up right condition for InlineExecutor
+    TestWorker.instance_variable_set(:@_server_chain, nil)
+    Shoryuken.shoryuken_options.instance_variable_set(:@_server_chain, nil)
     Shoryuken.worker_executor = described_class
+  end
+
+  after do
+    # Reset values on memory to not affect other examples
+    TestWorker.instance_variable_set(:@_server_chain, nil)
+    Shoryuken.shoryuken_options.instance_variable_set(:@_server_chain, nil)
+    Shoryuken.worker_executor = Shoryuken::Worker::DefaultExecutor
   end
 
   describe '.perform_async' do
@@ -44,6 +54,58 @@ RSpec.describe Shoryuken::Worker::InlineExecutor do
 
         TestWorker.perform_in(60, 'test')
       end
+    end
+  end
+
+  describe 'with custom middleware' do
+    subject do
+      -> { worker_klass.perform_async({}) }
+    end
+
+    shared_examples 'middleware#call method called' do
+      specify { is_expected.to output("Custom middleware called\n").to_stdout }
+    end
+
+    context 'register middleware for each worker' do
+      let(:worker_klass) do
+        middleware = Class.new do
+          def call(*_)
+            puts 'Custom middleware called'
+          end
+        end
+
+        Class.new(TestWorker) do
+          server_middleware do |chain|
+            chain.add middleware
+          end
+        end
+      end
+
+      include_examples 'middleware#call method called'
+    end
+
+    context 'register middleware globally' do
+      before do
+        middleware = Class.new do
+          def call(*_)
+            puts 'Custom middleware called'
+          end
+        end
+
+        Shoryuken.configure_server do |config|
+          config.server_middleware do |chain|
+            chain.add middleware
+          end
+        end
+      end
+
+      let(:worker_klass) do
+        Class.new(TestWorker) do
+          def perform(*_); end
+        end
+      end
+
+      include_examples 'middleware#call method called'
     end
   end
 end


### PR DESCRIPTION
I'd like to test my custom middleware that is for server with InlineExecutor, but InlineExecutor evaluate default_server_middleware without evaluate custom middleware. It's caused by [InlineExecutor#call](https://github.com/phstc/shoryuken/blob/v5.0.5/lib/shoryuken/worker/inline_executor.rb#L30-L35).
When we use DefaultExecutor, Shoryuken::Worker#perform is called by [Processor#process](https://github.com/phstc/shoryuken/blob/bc7938942270a1171d1597064698d88c3f36a4ec/lib/shoryuken/processor.rb#L21). At that time middleware#call is evaluated before call Shoryuken::Worker#perform. However InlineExecutor#call doesn't evaluate middleware#call before call Shoryuken::Worker#perform.

Why don't we evaluate middleware for InlineExecutor??😄 