### PR TITLE
Allow SQS SendMessage parameters to be specified when using ActiveJob

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -89,6 +89,7 @@ module Shoryuken
 end
 
 if Shoryuken.active_job?
+  require 'shoryuken/extensions/active_job_extensions'
   require 'shoryuken/extensions/active_job_adapter'
   require 'shoryuken/extensions/active_job_concurrent_send_adapter'
 end

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -71,6 +71,7 @@ module Shoryuken
           end
         end
         if Shoryuken.active_job?
+          require 'shoryuken/extensions/active_job_extensions'
           require 'shoryuken/extensions/active_job_adapter'
           require 'shoryuken/extensions/active_job_concurrent_send_adapter'
         end

--- a/lib/shoryuken/extensions/active_job_extensions.rb
+++ b/lib/shoryuken/extensions/active_job_extensions.rb
@@ -15,10 +15,11 @@ module Shoryuken
       end
 
       def enqueue(options = {})
-        sqs_send_message_parameters[:message_group_id] = options[:message_group_id] if options[:message_group_id]
-        sqs_send_message_parameters[:message_deduplication_id] = options[:message_deduplication_id] if options[:message_deduplication_id]
-        sqs_send_message_parameters[:message_attributes] = options[:message_attributes] if options[:message_attributes]
-        sqs_send_message_parameters[:message_system_attributes] = options[:message_system_attributes] if options[:message_system_attributes]
+        sqs_options = options.extract! :message_attributes,
+                                       :message_system_attributes,
+                                       :message_deduplication_id,
+                                       :message_group_id
+        sqs_send_message_parameters.merge! sqs_options
 
         super
       end

--- a/lib/shoryuken/extensions/active_job_extensions.rb
+++ b/lib/shoryuken/extensions/active_job_extensions.rb
@@ -13,6 +13,12 @@ module Shoryuken
         super(*arguments)
         self.sqs_send_message_parameters = {}
       end
+
+      def enqueue(options = {})
+        sqs_send_message_parameters[:message_group_id] = options[:message_group_id] if options[:message_group_id]
+
+        super
+      end
     end
   end
 end

--- a/lib/shoryuken/extensions/active_job_extensions.rb
+++ b/lib/shoryuken/extensions/active_job_extensions.rb
@@ -1,0 +1,21 @@
+module Shoryuken
+  module ActiveJobExtensions
+    module SQSSendMessageParametersAccessor
+      extend ActiveSupport::Concern
+
+      included do
+        attr_accessor :sqs_send_message_parameters
+      end
+    end
+
+    module SQSSendMessageParametersSupport
+      def initialize(*arguments)
+        super(*arguments)
+        self.sqs_send_message_parameters = {}
+      end
+    end
+  end
+end
+
+ActiveJob::Base.include Shoryuken::ActiveJobExtensions::SQSSendMessageParametersAccessor
+ActiveJob::Base.prepend Shoryuken::ActiveJobExtensions::SQSSendMessageParametersSupport

--- a/lib/shoryuken/extensions/active_job_extensions.rb
+++ b/lib/shoryuken/extensions/active_job_extensions.rb
@@ -16,6 +16,7 @@ module Shoryuken
 
       def enqueue(options = {})
         sqs_send_message_parameters[:message_group_id] = options[:message_group_id] if options[:message_group_id]
+        sqs_send_message_parameters[:message_deduplication_id] = options[:message_deduplication_id] if options[:message_deduplication_id]
 
         super
       end

--- a/lib/shoryuken/extensions/active_job_extensions.rb
+++ b/lib/shoryuken/extensions/active_job_extensions.rb
@@ -17,6 +17,7 @@ module Shoryuken
       def enqueue(options = {})
         sqs_send_message_parameters[:message_group_id] = options[:message_group_id] if options[:message_group_id]
         sqs_send_message_parameters[:message_deduplication_id] = options[:message_deduplication_id] if options[:message_deduplication_id]
+        sqs_send_message_parameters[:message_attributes] = options[:message_attributes] if options[:message_attributes]
 
         super
       end

--- a/lib/shoryuken/extensions/active_job_extensions.rb
+++ b/lib/shoryuken/extensions/active_job_extensions.rb
@@ -1,5 +1,8 @@
 module Shoryuken
   module ActiveJobExtensions
+    # Adds an accessor for SQS SendMessage parameters on ActiveJob jobs
+    # (instances of ActiveJob::Base). Shoryuken ActiveJob queue adapters use
+    # these parameters when enqueueing jobs; other adapters can ignore them.
     module SQSSendMessageParametersAccessor
       extend ActiveSupport::Concern
 
@@ -8,6 +11,9 @@ module Shoryuken
       end
     end
 
+    # Initializes SQS SendMessage parameters on instances of ActiveJobe::Base
+    # to the empty hash, and populates it whenever `#enqueue` is called, such
+    # as when using ActiveJob::Base.set.
     module SQSSendMessageParametersSupport
       def initialize(*arguments)
         super(*arguments)

--- a/lib/shoryuken/extensions/active_job_extensions.rb
+++ b/lib/shoryuken/extensions/active_job_extensions.rb
@@ -18,6 +18,7 @@ module Shoryuken
         sqs_send_message_parameters[:message_group_id] = options[:message_group_id] if options[:message_group_id]
         sqs_send_message_parameters[:message_deduplication_id] = options[:message_deduplication_id] if options[:message_deduplication_id]
         sqs_send_message_parameters[:message_attributes] = options[:message_attributes] if options[:message_attributes]
+        sqs_send_message_parameters[:message_system_attributes] = options[:message_system_attributes] if options[:message_system_attributes]
 
         super
       end

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 RSpec.shared_examples 'active_job_adapters' do
-  let(:job) { double 'Job', id: '123', queue_name: 'queue' }
+  let(:job_sqs_send_message_parameters) { {} }
+  let(:job) { double 'Job', id: '123', queue_name: 'queue', sqs_send_message_parameters: job_sqs_send_message_parameters }
   let(:fifo) { false }
   let(:queue) { double 'Queue', fifo?: fifo }
 

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -64,6 +64,28 @@ RSpec.shared_examples 'active_job_adapters' do
           subject.enqueue(job, message_group_id: 'options-group-id')
         end
       end
+
+      context 'when message_group_id is specified on the job' do
+        let(:job_sqs_send_message_parameters) { { message_group_id: 'job-group-id' } }
+
+        it 'should enqueue a message with the group_id specified on the job' do
+          expect(queue).to receive(:send_message) do |hash|
+            expect(hash[:message_group_id]).to eq('job-group-id')
+          end
+          subject.enqueue job
+        end
+      end
+
+      context 'when message_group_id is specified on the job and also in options' do
+        let(:job_sqs_send_message_parameters) { { message_group_id: 'job-group-id' } }
+
+        it 'should enqueue a message with the group_id specified in options' do
+          expect(queue).to receive(:send_message) do |hash|
+            expect(hash[:message_group_id]).to eq('options-group-id')
+          end
+          subject.enqueue(job, message_group_id: 'options-group-id')
+        end
+      end
     end
 
     context 'with additional message attributes' do

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -87,6 +87,24 @@ RSpec.shared_examples 'active_job_adapters' do
     end
   end
 
+  context 'with message_system_attributes' do
+    context 'when message_system_attributes are specified in options' do
+      it 'should enqueue a message with message_system_attributes specified in options' do
+        system_attributes = {
+          'AWSTraceHeader' => {
+            string_value: 'trace_id',
+            data_type: 'String'
+          }
+        }
+        expect(queue).to receive(:send_message) do |hash|
+          expect(hash[:message_system_attributes]['AWSTraceHeader'][:string_value]).to eq('trace_id')
+          expect(hash[:message_system_attributes]['AWSTraceHeader'][:data_type]).to eq('String')
+        end
+        subject.enqueue(job, message_system_attributes: system_attributes)
+      end
+    end
+  end
+
   describe '#enqueue_at' do
     specify do
       delay = 1

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -43,6 +43,17 @@ RSpec.shared_examples 'active_job_adapters' do
       end
     end
 
+    context 'with message_group_id' do
+      context 'when message_group_id is specified in options' do
+        it 'should enqueue a message with the group_id specified in options' do
+          expect(queue).to receive(:send_message) do |hash|
+            expect(hash[:message_group_id]).to eq('options-group-id')
+          end
+          subject.enqueue(job, message_group_id: 'options-group-id')
+        end
+      end
+    end
+
     context 'with additional message attributes' do
       it 'should combine with activejob attributes' do
         custom_message_attributes = {

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -41,6 +41,17 @@ RSpec.shared_examples 'active_job_adapters' do
 
         subject.enqueue(job)
       end
+
+      context 'with message_deduplication_id' do
+        context 'when message_deduplication_id is specified in options' do
+          it 'should enqueue a message with the deduplication_id specified in options' do
+            expect(queue).to receive(:send_message) do |hash|
+              expect(hash[:message_deduplication_id]).to eq('options-dedupe-id')
+            end
+            subject.enqueue(job, message_deduplication_id: 'options-dedupe-id')
+          end
+        end
+      end
     end
 
     context 'with message_group_id' do

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -52,6 +52,28 @@ RSpec.shared_examples 'active_job_adapters' do
             subject.enqueue(job, message_deduplication_id: 'options-dedupe-id')
           end
         end
+
+        context 'when message_deduplication_id is specified on the job' do
+          let(:job_sqs_send_message_parameters) { { message_deduplication_id: 'job-dedupe-id' } }
+
+          it 'should enqueue a message with the deduplication_id specified on the job' do
+            expect(queue).to receive(:send_message) do |hash|
+              expect(hash[:message_deduplication_id]).to eq('job-dedupe-id')
+            end
+            subject.enqueue job
+          end
+        end
+
+        context 'when message_deduplication_id is specified on the job and also in options' do
+          let(:job_sqs_send_message_parameters) { { message_deduplication_id: 'job-dedupe-id' } }
+
+          it 'should enqueue a message with the deduplication_id specified in options' do
+            expect(queue).to receive(:send_message) do |hash|
+              expect(hash[:message_deduplication_id]).to eq('options-dedupe-id')
+            end
+            subject.enqueue(job, message_deduplication_id: 'options-dedupe-id')
+          end
+        end
       end
     end
 

--- a/spec/shoryuken/extensions/active_job_base_spec.rb
+++ b/spec/shoryuken/extensions/active_job_base_spec.rb
@@ -41,5 +41,19 @@ RSpec.describe ActiveJob::Base do
 
       subject.set(message_deduplication_id: 'dedupe-id').perform_later 1, 2
     end
+
+    it 'passes message_attributes to the queue_adapter' do
+      message_attributes = {
+        'custom_tracing_id' => {
+          string_value: 'value',
+          data_type: 'String'
+        }
+      }
+      expect(queue_adapter).to receive(:enqueue) do |job|
+        expect(job.sqs_send_message_parameters[:message_attributes]).to eq(message_attributes)
+      end
+
+      subject.set(message_attributes: message_attributes).perform_later 1, 2
+    end
   end
 end

--- a/spec/shoryuken/extensions/active_job_base_spec.rb
+++ b/spec/shoryuken/extensions/active_job_base_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'active_job'
+require 'shoryuken/extensions/active_job_extensions'
 require 'shoryuken/extensions/active_job_adapter'
 
 RSpec.describe ActiveJob::Base do

--- a/spec/shoryuken/extensions/active_job_base_spec.rb
+++ b/spec/shoryuken/extensions/active_job_base_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'active_job'
+require 'shoryuken/extensions/active_job_adapter'
+
+RSpec.describe ActiveJob::Base do
+  let(:queue_adapter) { ActiveJob::QueueAdapters::ShoryukenAdapter.new }
+
+  subject do
+    worker_class = Class.new(described_class)
+    Object.const_set :MyWorker, worker_class
+    worker_class.queue_adapter = queue_adapter
+    worker_class
+  end
+
+  after do
+    Object.send :remove_const, :MyWorker
+  end
+
+  describe '#perform_later' do
+    it 'calls enqueue on the adapter with the expected job' do
+      expect(queue_adapter).to receive(:enqueue) do |job|
+        expect(job.arguments).to eq([1, 2])
+      end
+
+      subject.perform_later 1, 2
+    end
+  end
+end

--- a/spec/shoryuken/extensions/active_job_base_spec.rb
+++ b/spec/shoryuken/extensions/active_job_base_spec.rb
@@ -55,5 +55,19 @@ RSpec.describe ActiveJob::Base do
 
       subject.set(message_attributes: message_attributes).perform_later 1, 2
     end
+
+    it 'passes message_system_attributes to the queue_adapter' do
+      message_system_attributes = {
+        'AWSTraceHeader' => {
+          string_value: 'trace_id',
+          data_type: 'String'
+        }
+      }
+      expect(queue_adapter).to receive(:enqueue) do |job|
+        expect(job.sqs_send_message_parameters[:message_system_attributes]).to eq(message_system_attributes)
+      end
+
+      subject.set(message_system_attributes: message_system_attributes).perform_later 1, 2
+    end
   end
 end

--- a/spec/shoryuken/extensions/active_job_base_spec.rb
+++ b/spec/shoryuken/extensions/active_job_base_spec.rb
@@ -33,5 +33,13 @@ RSpec.describe ActiveJob::Base do
 
       subject.set(message_group_id: 'group-2').perform_later 1, 2
     end
+
+    it 'passes message_deduplication_id to the queue_adapter' do
+      expect(queue_adapter).to receive(:enqueue) do |job|
+        expect(job.sqs_send_message_parameters[:message_deduplication_id]).to eq('dedupe-id')
+      end
+
+      subject.set(message_deduplication_id: 'dedupe-id').perform_later 1, 2
+    end
   end
 end

--- a/spec/shoryuken/extensions/active_job_base_spec.rb
+++ b/spec/shoryuken/extensions/active_job_base_spec.rb
@@ -25,5 +25,13 @@ RSpec.describe ActiveJob::Base do
 
       subject.perform_later 1, 2
     end
+
+    it 'passes message_group_id to the queue_adapter' do
+      expect(queue_adapter).to receive(:enqueue) do |job|
+        expect(job.sqs_send_message_parameters[:message_group_id]).to eq('group-2')
+      end
+
+      subject.set(message_group_id: 'group-2').perform_later 1, 2
+    end
   end
 end


### PR DESCRIPTION
Adds support for specifying SQS SendMessage parameters as described in  #646

For example,

```ruby
class MyJob < ApplicationJob
  def perform(a, b); end
end

MyJob.set(message_group_id: 'abc123',
          message_deduplication_id: 'dedupe',
          message_attributes: {
            'key' => {
              string_value: 'myvalue',
              data_type: 'String'
            }
          })
     .perform_later(123, 'abc')
```