### PR TITLE
Run specs with Github Actions

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -8,7 +8,10 @@ jobs:
     strategy:
       matrix:
         ruby: ['2.4.4', '2.5.1', '2.6.3']
+        gemfile: ['Gemfile', 'Gemfile.aws-sdk-core-v2']
     runs-on: ubuntu-20.04
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -23,3 +23,33 @@ jobs:
         env:
           SPEC_ALL: true
         run: bundle exec rake spec
+  rails_specs:
+    name: Rails Specs
+    strategy:
+      matrix:
+        rails: ['4.2', '5.2', '6.0', '6.1']
+        include:
+          - rails: '4.2'
+            ruby: '2.2'
+            gemfile: gemfiles/rails_4_2.gemfile
+          - rails: '5.2'
+            ruby: '2.5'
+            gemfile: gemfiles/rails_5_2.gemfile
+          - rails: '6.0'
+            ruby: '2.6'
+            gemfile: gemfiles/rails_6_0.gemfile
+          - rails: '6.1'
+            ruby: '3.0'
+            gemfile: gemfiles/rails_6_1.gemfile
+    runs-on: ubuntu-20.04
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run Rails specs
+        run: bundle exec rake rails_specs

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,0 +1,22 @@
+name: Specs
+
+on: push
+
+jobs:
+  all_specs:
+    name: All Specs
+    strategy:
+      matrix:
+        ruby: ['2.4.4', '2.5.1', '2.6.3']
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run specs
+        env:
+          SPEC_ALL: true
+        run: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 Shoryuken _sho-ryu-ken_ is a super-efficient [Amazon SQS](https://aws.amazon.com/sqs/) thread-based message processor.
 
+[![Build Status](https://github.com/ruby-shoryuken/shoryuken/workflows/Specs/badge.svg)](https://github.com/ruby-shoryuken/shoryuken/actions)
 [![Build Status](https://travis-ci.org/phstc/shoryuken.svg)](https://travis-ci.org/phstc/shoryuken)
 [![Code Climate](https://codeclimate.com/github/phstc/shoryuken/badges/gpa.svg)](https://codeclimate.com/github/phstc/shoryuken)
 


### PR DESCRIPTION
This change replicates the current usage of Travis CI with Github Actions

Example run on my fork: https://github.com/cjlarose/shoryuken/actions/runs/526654363

We'll stop using Travis in a follow-up PR