### PR TITLE
Allow access to computed SQS SendMessage parameters when using ActiveJob

### DIFF
--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -36,7 +36,9 @@ module ActiveJob
         job.sqs_send_message_parameters.merge! options
 
         queue = Shoryuken::Client.queues(job.queue_name)
-        queue.send_message(message(queue, job))
+        send_message_params = message queue, job
+        job.sqs_send_message_parameters = send_message_params
+        queue.send_message send_message_params
       end
 
       def enqueue_at(job, timestamp) #:nodoc:

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -1,19 +1,22 @@
+require 'active_job'
+require 'shoryuken/extensions/active_job_extensions'
+
+# Stand-in for a job class specified by the user
+class TestJob < ActiveJob::Base; end
+
 # rubocop:disable Metrics/BlockLength
 RSpec.shared_examples 'active_job_adapters' do
   let(:job_sqs_send_message_parameters) { {} }
-  let(:job) { double 'Job', id: '123', queue_name: 'queue', sqs_send_message_parameters: job_sqs_send_message_parameters }
+  let(:job) do
+    job = TestJob.new
+    job.sqs_send_message_parameters = job_sqs_send_message_parameters
+    job
+  end
   let(:fifo) { false }
   let(:queue) { double 'Queue', fifo?: fifo }
 
   before do
     allow(Shoryuken::Client).to receive(:queues).with(job.queue_name).and_return(queue)
-    allow(job).to receive(:serialize).and_return(
-      'job_class' => 'Worker',
-      'job_id' => job.id,
-      'queue_name' => job.queue_name,
-      'arguments' => nil,
-      'locale' => nil
-    )
   end
 
   describe '#enqueue' do

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -32,6 +32,13 @@ RSpec.shared_examples 'active_job_adapters' do
       subject.enqueue(job)
     end
 
+    it "should mutate the job's sqs_send_message_parameters reference to match those sent to the queue" do
+      expect(queue).to receive(:send_message) do |options|
+        expect(options).to be(job.sqs_send_message_parameters)
+      end
+      subject.enqueue(job)
+    end
+
     context 'when fifo' do
       let(:fifo) { true }
 

--- a/spec/shoryuken/extensions/active_job_adapter_spec.rb
+++ b/spec/shoryuken/extensions/active_job_adapter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
-require 'shoryuken/extensions/active_job_adapter'
 require 'shared_examples_for_active_job'
+require 'shoryuken/extensions/active_job_adapter'
 
 RSpec.describe ActiveJob::QueueAdapters::ShoryukenAdapter do
   include_examples 'active_job_adapters'


### PR DESCRIPTION
When enqueuing a message with ActiveJob, the SQS SendMessage parameters undergo several important transformations:

* The `shoryuken_class` `:message_attribute` is added
* Client middleware is applied
* `:message_group_id` and `:message_deduplication_id` are set for FIFO queues if those options were unspecified

Since we store SQS SendMessage parameters on the ActiveJob job instance itself, they're accessible to the caller:

```ruby
job = AddJob.set(queue: 'shoryuken_test.fifo')
            .perform_later(123, 321)
job.sqs_send_message_parameters
```

This change modifies the `sqs_send_message_parameters` reference to be the same object that's sent into `Shoryuken::Queue#send_message`. That way, the caller has access to the complete set of computed SQS
SendMessage parameters, not just the ones that were specified by the caller (for example, when using `.set`).

This makes it possible, for instance, to log important information like the `message_deduplication_id` on the enqueuer side. It also gives important feedback to users so that they know exactly what parameters were sent to SQS.

Related: #646