### PR TITLE
Fix keyword argument error

### DIFF
--- a/lib/shoryuken/extensions/active_job_extensions.rb
+++ b/lib/shoryuken/extensions/active_job_extensions.rb
@@ -19,6 +19,7 @@ module Shoryuken
         super(*arguments)
         self.sqs_send_message_parameters = {}
       end
+      ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
       def enqueue(options = {})
         sqs_options = options.extract! :message_attributes,

--- a/spec/shoryuken/extensions/active_job_base_spec.rb
+++ b/spec/shoryuken/extensions/active_job_base_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe ActiveJob::Base do
     Object.send :remove_const, :MyWorker
   end
 
+  describe '#perform_now' do
+    it 'allows keyward args' do
+      collaborator = double 'worker collaborator'
+      subject.send(:define_method, :perform) do |**kwargs|
+        collaborator.foo(**kwargs)
+      end
+      expect(collaborator).to receive(:foo).with(foo: 'bar')
+      subject.perform_now foo: 'bar'
+    end
+  end
+
   describe '#perform_later' do
     it 'calls enqueue on the adapter with the expected job' do
       expect(queue_adapter).to receive(:enqueue) do |job|


### PR DESCRIPTION
This PR fixes keyword arguments error in Active Job.
In `shoryuken v5.1.0` with `ruby 3.0.0p0`, `perform` method with keyword arguments causes `ArgumentError` as below.
```
class KwargsJob < ActiveJob::Base
  def perform(argument:)
    puts argument
  end
end

KwargsJob.perform_now(argument: 2) # => ArgumentError: wrong number of arguments (given 1, expected 0)
```
I suggest the same approach as Rails. ( https://github.com/rails/rails/pull/38267 )

@phstc @cjlarose 