### PR TITLE
Run integration tests on CI

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -22,8 +22,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run specs
-        env:
-          SPEC_ALL: true
         run: bundle exec rake spec
   rails_specs:
     name: Rails Specs

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -12,6 +12,11 @@ jobs:
         ruby: ['2.4.4', '2.5.1', '2.6.3']
         gemfile: ['Gemfile', 'Gemfile.aws-sdk-core-v2']
     runs-on: ubuntu-20.04
+    services:
+      moto_sqs:
+        image: quay.io/cjlarose/moto-sqs-server:1.1.0
+        ports:
+          - 5000:5000
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
@@ -23,6 +28,8 @@ jobs:
           bundler-cache: true
       - name: Run specs
         run: bundle exec rake spec
+      - name: Run integration specs
+        run: bundle exec rake spec:integration
   rails_specs:
     name: Rails Specs
     strategy:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -54,4 +54,4 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run Rails specs
-        run: bundle exec rake rails_specs
+        run: bundle exec rake spec:rails

--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ bundle exec rake spec
 To run all Rails-related specs against all supported versions of Rails, execute
 
 ```sh
-bundle exec appraisal rake rails_specs
+bundle exec appraisal rake spec:rails
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For more information check the [wiki page](https://github.com/phstc/shoryuken/wi
 
 ### Testing
 
-To run all specs against the latest dependency vesions, execute
+To run all unit specs against the latest dependency vesions, execute
 
 ```sh
 bundle exec rake spec
@@ -79,4 +79,10 @@ To run all Rails-related specs against all supported versions of Rails, execute
 
 ```sh
 bundle exec appraisal rake spec:rails
+```
+
+To run integration specs, start a mock SQS server on `localhost:5000`. One such option is [cjlarose/moto-sqs-server](https://github.com/cjlarose/moto-sqs-server). Then execute
+
+```sh
+bundle exec rake spec:integration
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,11 @@ begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
 
-  RSpec::Core::RakeTask.new(:rails_specs) do |t|
-    t.pattern = 'spec/shoryuken/{environment_loader_spec,extensions/active_job_*}.rb'
+  namespace :spec do
+    desc 'Run Rails specs only'
+    RSpec::Core::RakeTask.new(:rails) do |t|
+      t.pattern = 'spec/shoryuken/{environment_loader_spec,extensions/active_job_*}.rb'
+    end
   end
 rescue LoadError
 end

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,11 @@ begin
     RSpec::Core::RakeTask.new(:rails) do |t|
       t.pattern = 'spec/shoryuken/{environment_loader_spec,extensions/active_job_*}.rb'
     end
+
+    desc 'Run integration specs only'
+    RSpec::Core::RakeTask.new(:integration) do |t|
+      t.pattern = 'spec/integration/**/*_spec.rb'
+    end
   end
 rescue LoadError
 end

--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,9 @@ begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
 
-  rails_task = RSpec::Core::RakeTask.new(:rails_specs)
-  rails_task.pattern = 'spec/shoryuken/{environment_loader_spec,extensions/active_job_*}.rb'
+  RSpec::Core::RakeTask.new(:rails_specs) do |t|
+    t.pattern = 'spec/shoryuken/{environment_loader_spec,extensions/active_job_*}.rb'
+  end
 rescue LoadError
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,9 @@ $stdout.sync = true
 
 begin
   require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:spec)
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.exclude_pattern = 'spec/integration/**/*_spec.rb'
+  end
 
   namespace :spec do
     desc 'Run Rails specs only'

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -4,10 +4,29 @@ require 'shoryuken/launcher'
 require 'securerandom'
 
 RSpec.describe Shoryuken::Launcher do
+  let(:sqs_client) do
+    Aws::SQS::Client.new(
+      region: 'us-east-1',
+      endpoint: 'http://localhost:5000',
+      access_key_id: 'fake',
+      secret_access_key: 'fake'
+    )
+  end
+
   describe 'Consuming messages' do
     before do
       Aws.config[:stub_responses] = false
-      Aws.config[:region] = 'us-east-1'
+
+      executor = Concurrent::ThreadPoolExecutor.new(min_threads: 4)
+      Shoryuken.launcher_executor = executor
+
+      Shoryuken.configure_client do |config|
+        config.sqs_client = sqs_client
+      end
+
+      Shoryuken.configure_server do |config|
+        config.sqs_client = sqs_client
+      end
 
       StandardWorker.received_messages = 0
 
@@ -25,6 +44,7 @@ RSpec.describe Shoryuken::Launcher do
 
     after do
       Aws.config[:stub_responses] = true
+      Shoryuken.launcher_executor = nil
 
       queue_url = Shoryuken::Client.sqs.get_queue_url(
         queue_name: StandardWorker.get_shoryuken_options['queue']

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -4,7 +4,7 @@ require 'shoryuken/launcher'
 require 'securerandom'
 
 RSpec.describe Shoryuken::Launcher do
-  describe 'Consuming messages', slow: true do
+  describe 'Consuming messages' do
     before do
       Aws.config[:stub_responses] = false
       Aws.config[:region] = 'us-east-1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,9 +32,6 @@ class TestWorker
 end
 
 RSpec.configure do |config|
-  # TODO: Run these tests again on CI
-  config.filter_run_excluding slow: true
-
   config.before do
     Shoryuken::Client.class_variable_set :@@queues, {}
 


### PR DESCRIPTION
The integration tests appear to have been disabled as part of the migration to Travis CI in e7e5f2e9e3bf76d8ef99d451b79c1b5852ee0ad1

I think the tests originally connected to real SQS servers, but in the interest of saving myself from setting up real AWS credentials and making it easier for contributors to run the tests in Github Actions in forks of this repository, this PR runs the tests against a local moto server.