### PR TITLE
Remove global stub for Concurrent.global_io_executor

### DIFF
--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -14,7 +14,12 @@ RSpec.describe Shoryuken::Launcher do
   end
 
   let(:executor) do
-    Concurrent::ThreadPoolExecutor.new(min_threads: 4)
+    # We can't use Concurrent.global_io_executor in these tests since once you
+    # shut down a thread pool, you can't start it back up. Instead, we create
+    # one new thread pool executor for each spec. We use a new
+    # CachedThreadPool, since that most closely resembles
+    # Concurrent.global_io_executor
+    Concurrent::CachedThreadPool.new auto_terminate: true
   end
 
   describe 'Consuming messages' do

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -13,12 +13,15 @@ RSpec.describe Shoryuken::Launcher do
     )
   end
 
+  let(:executor) do
+    Concurrent::ThreadPoolExecutor.new(min_threads: 4)
+  end
+
   describe 'Consuming messages' do
     before do
       Aws.config[:stub_responses] = false
 
-      executor = Concurrent::ThreadPoolExecutor.new(min_threads: 4)
-      Shoryuken.launcher_executor = executor
+      allow(Shoryuken).to receive(:launcher_executor).and_return(executor)
 
       Shoryuken.configure_client do |config|
         config.sqs_client = sqs_client
@@ -44,7 +47,6 @@ RSpec.describe Shoryuken::Launcher do
 
     after do
       Aws.config[:stub_responses] = true
-      Shoryuken.launcher_executor = nil
 
       queue_url = Shoryuken::Client.sqs.get_queue_url(
         queue_name: StandardWorker.get_shoryuken_options['queue']

--- a/spec/shoryuken/extensions/active_job_concurrent_send_adapter_spec.rb
+++ b/spec/shoryuken/extensions/active_job_concurrent_send_adapter_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter do
   let(:error_handler) { -> {} }
   let(:success_handler) { -> {} }
 
+  before do
+    allow(Concurrent).to receive(:global_io_executor).and_return(Concurrent::ImmediateExecutor.new)
+  end
+
   subject { described_class.new(success_handler, error_handler) }
 
   context 'when success' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,6 @@ RSpec.configure do |config|
 
     Shoryuken.cache_visibility_timeout = false
 
-    allow(Concurrent).to receive(:global_io_executor).and_return(Concurrent::ImmediateExecutor.new)
     allow(Shoryuken).to receive(:active_job?).and_return(false)
   end
 end


### PR DESCRIPTION
Just cleans up some tests.