### PR TITLE
Adds a check to automatically adjust for batch size limit enforced by aws

### DIFF
--- a/bin/cli/sqs.rb
+++ b/bin/cli/sqs.rb
@@ -4,6 +4,9 @@ require 'date'
 module Shoryuken
   module CLI
     class SQS < Base
+      # See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
+      MAX_BATCH_SIZE = 256 * 1024
+
       namespace :sqs
       class_option :endpoint, aliases: '-e', type: :string, default: ENV['SHORYUKEN_SQS_ENDPOINT'], desc: 'Endpoint URL'
 
@@ -51,10 +54,15 @@ module Shoryuken
           end
         end
 
-        def batch_send(url, messages, messages_per_batch = 10)
-          messages.to_a.flatten.map(&method(:normalize_dump_message)).each_slice(messages_per_batch) do |batch|
-            sqs.send_message_batch(queue_url: url, entries: batch).failed.any? do |failure|
-              say "Could not requeue #{failure.id}, code: #{failure.code}", :yellow
+        def batch_send(url, messages, messages_per_batch = 10, rerun = false)
+          messages.to_a.flatten.map{ |message| !rerun ? normalize_dump_message(message) : message }.each_slice(messages_per_batch) do |batch|
+            if messages_per_batch == 1 || batch.join.bytesize < MAX_BATCH_SIZE
+              sqs.send_message_batch(queue_url: url, entries: batch).failed.any? do |failure|
+                say "Could not requeue #{failure.id}, code: #{failure.code}", :yellow
+              end
+            else
+              less_messages_per_batch = ((messages_per_batch / 2.0)).ceil
+              batch_send(url, batch, less_messages_per_batch, true)
             end
           end
         end


### PR DESCRIPTION
This addresses https://github.com/ruby-shoryuken/shoryuken/issues/663

The change to `batch_send` will ensure that a batch is never larger than the 256kb limit set by SQS. If the batch size is too large then it will recurse until the batch size is small enough.  If a single message is larger than the batch size limit then it will display the original error message but the rest of the batch will succeed.

These changes were tested using LocalStack.