### PR TITLE
Do not apply prefix to queues configured as URL or ARN

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -80,7 +80,7 @@ module Shoryuken
     end
 
     def prefix_active_job_queue_name(queue_name, weight)
-      return [queue_name, weight] if queue_name.start_with?('https://')
+      return [queue_name, weight] if queue_name.start_with?('https://', 'arn:')
 
       queue_name_prefix = ::ActiveJob::Base.queue_name_prefix
       queue_name_delimiter = ::ActiveJob::Base.queue_name_delimiter

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -80,6 +80,8 @@ module Shoryuken
     end
 
     def prefix_active_job_queue_name(queue_name, weight)
+      return [queue_name, weight] if queue_name.start_with?('https://')
+
       queue_name_prefix = ::ActiveJob::Base.queue_name_prefix
       queue_name_delimiter = ::ActiveJob::Base.queue_name_delimiter
 

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Shoryuken::EnvironmentLoader do
       expect(Shoryuken.groups['group1'][:queues]).to(eq(['https://example.com/test_group1_queue1']))
     end
 
-    it 'does not prefix arn-based queues', pending: 'current behaviour' do
+    it 'does not prefix arn-based queues' do
       Shoryuken.options[:queues] = ['arn:aws:sqs:fake-region-1:1234:test_queue1']
       Shoryuken.options[:groups] = {'group1' => {queues: ['arn:aws:sqs:fake-region-1:1234:test_group1_queue1']}}
 

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Shoryuken::EnvironmentLoader do
       expect(Shoryuken.groups['default'][:queues]).to eq(%w[test_queue1 test_queue2 test_queue2])
       expect(Shoryuken.groups['group1'][:queues]).to eq(%w[test_group1_queue1 test_group1_queue2])
     end
+
+    it 'does not prefix url-based queues', pending: 'current behaviour' do
+      Shoryuken.options[:queues] = ['https://example.com/test_queue1']
+      Shoryuken.options[:groups] = {'group1' => {queues: ['https://example.com/test_group1_queue1']}}
+
+      subject.load
+
+      expect(Shoryuken.groups['default'][:queues]).to(eq(['https://example.com/test_queue1']))
+      expect(Shoryuken.groups['group1'][:queues]).to(eq(['https://example.com/test_group1_queue1']))
+    end
   end
   describe "#setup_options" do
     let (:cli_queues) { { "queue1"=> 10, "queue2" => 20 } }

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -57,11 +57,11 @@ RSpec.describe Shoryuken::EnvironmentLoader do
       ActiveJob::Base.queue_name_delimiter = '_'
 
       allow(Shoryuken).to receive(:active_job?).and_return(true)
+
+      Shoryuken.active_job_queue_name_prefixing = true
     end
 
     specify do
-      Shoryuken.active_job_queue_name_prefixing = true
-
       Shoryuken.options[:queues] = ['queue1', ['queue2', 2]]
 
       Shoryuken.options[:groups] = {

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Shoryuken::EnvironmentLoader do
       expect(Shoryuken.groups['group1'][:queues]).to eq(%w[test_group1_queue1 test_group1_queue2])
     end
 
-    it 'does not prefix url-based queues', pending: 'current behaviour' do
+    it 'does not prefix url-based queues' do
       Shoryuken.options[:queues] = ['https://example.com/test_queue1']
       Shoryuken.options[:groups] = {'group1' => {queues: ['https://example.com/test_group1_queue1']}}
 

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -83,6 +83,16 @@ RSpec.describe Shoryuken::EnvironmentLoader do
       expect(Shoryuken.groups['default'][:queues]).to(eq(['https://example.com/test_queue1']))
       expect(Shoryuken.groups['group1'][:queues]).to(eq(['https://example.com/test_group1_queue1']))
     end
+
+    it 'does not prefix arn-based queues', pending: 'current behaviour' do
+      Shoryuken.options[:queues] = ['arn:aws:sqs:fake-region-1:1234:test_queue1']
+      Shoryuken.options[:groups] = {'group1' => {queues: ['arn:aws:sqs:fake-region-1:1234:test_group1_queue1']}}
+
+      subject.load
+
+      expect(Shoryuken.groups['default'][:queues]).to(eq(['arn:aws:sqs:fake-region-1:1234:test_queue1']))
+      expect(Shoryuken.groups['group1'][:queues]).to(eq(['arn:aws:sqs:fake-region-1:1234:test_group1_queue1']))
+    end
   end
   describe "#setup_options" do
     let (:cli_queues) { { "queue1"=> 10, "queue2" => 20 } }


### PR DESCRIPTION
💁  View per-commit for red -> green spec journey.

## :thinking: Issue

_What problem are you trying to solve?_

When queue name prefixing is enabled, prefixes are applied to ARN and URL based queues.

```ruby
# in our case this is configured via the ActiveJob integration
config.active_job.queue_name_prefix = 'my_prefix'
```

```yml
groups:
  normal:
    concurrency: 2
    polling_strategy: StrictPriority
    queues:
      - arn:aws:sqs:fake-region-1:12345:my_queue_name
      - https://example.co/my_queue_name_2
```

```
ArgumentError: The specified queue(s) my_prefix_arn:aws:sqs:fake-region-1:12345:my_queue_name do not exist.
```

```
ArgumentError: The specified queue(s) my_prefix_https://example.co/my_queue_name_2 do not exist.
```

## :relieved: Solution

_How did you solve the problem?_

Skip applying prefix to queues configured via ARN or URL.
Still apply the prefix to queues configured via name.

## :microscope: Testing

_How did you test this?_

✅  specs
✅  local sanity check integrated with our rails app

