### PR TITLE
Initialize Rails before parsing Config File

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -80,7 +80,7 @@ module Shoryuken
     end
 
     def load_rails?
-      options[:rails] || Shoryuken.options[:rails]
+      options[:rails]
     end
 
     def prefix_active_job_queue_name(queue_name, weight)

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -18,12 +18,12 @@ module Shoryuken
     end
 
     def setup_options
+      load_rails if Shoryuken.options[:rails]
       initialize_options
       initialize_logger
     end
 
     def load
-      load_rails if Shoryuken.options[:rails]
       prefix_active_job_queue_names
       parse_queues
       require_workers

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -18,7 +18,7 @@ module Shoryuken
     end
 
     def setup_options
-      load_rails if Shoryuken.options[:rails]
+      load_rails if options[:rails] || Shoryuken.options[:rails]
       initialize_options
       initialize_logger
     end

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -18,7 +18,7 @@ module Shoryuken
     end
 
     def setup_options
-      load_rails if options[:rails] || Shoryuken.options[:rails]
+      initialize_rails if load_rails?
       initialize_options
       initialize_logger
     end
@@ -55,7 +55,7 @@ module Shoryuken
       Shoryuken.logger.level = Logger::DEBUG if Shoryuken.options[:verbose]
     end
 
-    def load_rails
+    def initialize_rails
       # Adapted from: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb
 
       require 'rails'
@@ -77,6 +77,10 @@ module Shoryuken
         end
         require File.expand_path('config/environment.rb')
       end
+    end
+
+    def load_rails?
+      options[:rails] || Shoryuken.options[:rails]
     end
 
     def prefix_active_job_queue_name(queue_name, weight)

--- a/lib/shoryuken/runner.rb
+++ b/lib/shoryuken/runner.rb
@@ -30,9 +30,6 @@ module Shoryuken
 
       loader = EnvironmentLoader.setup_options(options)
 
-      # When cli args exist, override options in config file
-      Shoryuken.options.merge!(options)
-
       daemonize(Shoryuken.options)
       write_pid(Shoryuken.options)
 

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Shoryuken::EnvironmentLoader do
 
   describe '#parse_queues loads default queues' do
     before do
-      allow(subject).to receive(:load_rails)
+      allow(subject).to receive(:initialize_rails)
       allow(subject).to receive(:prefix_active_job_queue_names)
       allow(subject).to receive(:require_workers)
       allow(subject).to receive(:validate_queues)
@@ -24,7 +24,7 @@ RSpec.describe Shoryuken::EnvironmentLoader do
 
   describe '#parse_queues includes delay per groups' do
     before do
-      allow(subject).to receive(:load_rails)
+      allow(subject).to receive(:initialize_rails)
       allow(subject).to receive(:prefix_active_job_queue_names)
       allow(subject).to receive(:require_workers)
       allow(subject).to receive(:validate_queues)
@@ -47,7 +47,7 @@ RSpec.describe Shoryuken::EnvironmentLoader do
 
   describe '#prefix_active_job_queue_names' do
     before do
-      allow(subject).to receive(:load_rails)
+      allow(subject).to receive(:initialize_rails)
       allow(subject).to receive(:require_workers)
       allow(subject).to receive(:validate_queues)
       allow(subject).to receive(:validate_workers)


### PR DESCRIPTION
## Part 1

### Description

When you specify to load rails in the `shoryuken.yml` file ( i.e `rails: true`), `Shoryuken::EnvironmentLoader#setup_options` will read the `config_file` before rails has had a chance to be initialized. Any declared rails environment variables will not be present at this time. 

In the example below: 
```ruby
# config/shoryuken.yml

------------
delay: 25
queues:
  - <%= ENV['AWS_SQS_QUEUE'] %>
```
`AWS_SQS_QUEUE` will not be present in the rails environment variables as it is currently. As a result a log output will show this message: `WARN: No queues supplied`

### Fixes:
Initialize rails as the first step in the `#setup_options` 

## Part 2

### Description

Currently if you set the `:rails` flag in the CLI with the `-R` option, the `Shoryuken::Runner` will override options in the config files with the CLI options
```ruby
# lib/shoryuken/runner.rb

loader = EnvironmentLoader.setup_options(options)

# When cli args exist, override options in config file
Shoryuken.options.merge!(options)

loader.load
```

When `loader.load` gets called, we run into the same issue as Part 1. The `config_file` has already been read-in and any rails environment variables were not present at that time. Again, this is because loading rails happens too late in the process, in the `#load` method.

### Fixes
`Shoryuken::EnvironmentLoader` will initialize rails looking for flags from either `Shoryuken.options` or CLI `options` hash. See `load_rails?` method.

## Other

Fixes issues similar to these #670
> Because even though I use the dotenv gem, the environment variables are not loaded properly by Shoryuken.
It does work when they exist on the OS level

Similar Issues #511 