### PR TITLE
Preserve queue weights when unpausing

### DIFF
--- a/lib/shoryuken/polling/strict_priority.rb
+++ b/lib/shoryuken/polling/strict_priority.rb
@@ -39,8 +39,10 @@ module Shoryuken
       end
 
       def message_processed(queue)
-        logger.debug "Unpausing #{queue}"
-        @paused_until[queue] = Time.at 0
+        if queue_paused?(queue)
+          logger.debug "Unpausing #{queue}"
+          @paused_until[queue] = Time.at 0
+        end
       end
 
       private

--- a/lib/shoryuken/polling/strict_priority.rb
+++ b/lib/shoryuken/polling/strict_priority.rb
@@ -40,7 +40,7 @@ module Shoryuken
 
       def message_processed(queue)
         logger.debug "Unpausing #{queue}"
-        @paused_until[queue] = Time.now
+        @paused_until[queue] = Time.at 0
       end
 
       private

--- a/lib/shoryuken/polling/weighted_round_robin.rb
+++ b/lib/shoryuken/polling/weighted_round_robin.rb
@@ -36,12 +36,10 @@ module Shoryuken
       end
 
       def message_processed(queue)
-        return if @paused_queues.empty?
+        paused_queue = @paused_queues.find { |_time, name| name == queue }
+        return unless paused_queue
 
-        logger.debug "Unpausing #{queue}"
-        @paused_queues.reject! { |_time, name| name == queue }
-        @queues << queue
-        @queues.uniq!
+        paused_queue[0] = Time.at 0
       end
 
       private


### PR DESCRIPTION
#644 introduced a change that unpauses FIFO queues when a message is processed from that queue. This prevents unnecessary delays, especially when using FIFO queues that contain messages with just a single unique `message_group_id`.

One side-effect of its implementation, however, reset queue weights in the `WeightedRoundRobin` polling strategy. In that class, `@queues` is an array of queue names, but some of the queue names are duplicated intentionally in order to represent weights. The change in #644 called `uniq!` on `@queues`, effectively resetting queue weights back down to 1 for all active (unpaused) queues. Since queue weights grow and shrink dynamically over time to adjust to the number of messages fetched from those queues, this is undesirable.

cc @davidrichey 