### PR TITLE
Add throttling support to StrictPriority

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -88,7 +88,8 @@ module Shoryuken
     :on,
     :cache_visibility_timeout?,
     :cache_visibility_timeout=,
-    :delay
+    :delay,
+    :interval
   )
 end
 

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -124,7 +124,7 @@ module Shoryuken
       end
 
       Shoryuken.options[:groups].to_a.each do |group, options|
-        Shoryuken.add_group(group, options[:concurrency], delay: options[:delay])
+        Shoryuken.add_group(group, options[:concurrency], delay: options[:delay], interval: options[:interval])
 
         options[:queues].to_a.each do |queue, weight|
           parse_queue(queue, weight, group)

--- a/lib/shoryuken/launcher.rb
+++ b/lib/shoryuken/launcher.rb
@@ -88,10 +88,12 @@ module Shoryuken
 
     def create_managers
       Shoryuken.groups.map do |group, options|
+        polling_options = { interval: Shoryuken.interval(group) }
+
         Shoryuken::Manager.new(
           group,
           Shoryuken::Fetcher.new(group),
-          Shoryuken.polling_strategy(group).new(options[:queues], Shoryuken.delay(group)),
+          Shoryuken.polling_strategy(group).new(options[:queues], Shoryuken.delay(group), polling_options),
           options[:concurrency],
           executor
         )

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -6,6 +6,7 @@ module Shoryuken
       aws: {},
       delay: 0.0,
       timeout: 8,
+      interval: 0.0,
       lifecycle_events: {
         startup: [],
         dispatch: [],
@@ -35,13 +36,15 @@ module Shoryuken
       defined?(::ActiveJob)
     end
 
-    def add_group(group, concurrency = nil, delay: nil)
+    def add_group(group, concurrency = nil, delay: nil, interval: nil)
       concurrency ||= options[:concurrency]
       delay ||= options[:delay]
+      interval ||= options[:interval]
 
       groups[group] ||= {
         concurrency: concurrency,
         delay: delay,
+        interval: interval,
         queues: []
       }
     end
@@ -72,6 +75,10 @@ module Shoryuken
 
     def delay(group)
       groups[group].to_h.fetch(:delay, options[:delay]).to_f
+    end
+
+    def interval(group)
+      groups[group].to_h.fetch(:interval, options[:interval]).to_f
     end
 
     def sqs_client

--- a/lib/shoryuken/polling/weighted_round_robin.rb
+++ b/lib/shoryuken/polling/weighted_round_robin.rb
@@ -1,7 +1,7 @@
 module Shoryuken
   module Polling
     class WeightedRoundRobin < BaseStrategy
-      def initialize(queues, delay = nil)
+      def initialize(queues, delay = nil, _options = {})
         @initial_queues = queues
         @queues = queues.dup.uniq
         @paused_queues = []

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,7 @@ RSpec.configure do |config|
 
     Shoryuken.options[:concurrency] = 1
     Shoryuken.options[:delay]       = 1.0
+    Shoryuken.options[:interval]    = nil
     Shoryuken.options[:timeout]     = 1
     Shoryuken.options[:daemon]      = nil
     Shoryuken.options[:logfile]     = nil


### PR DESCRIPTION
This PR adds support for an `interval` configuration option for queues and groups when using the `StrictPriority` polling strategy. The way `interval` works is that, when defined, Shoryuken will put a queue to sleep for `n * interval` seconds after fetching `n` messages. We wanted to implement this since we have a use case where we need to throttle how quickly Shoryuken pulls from specific queues and adding a configuration option like this would make that possible.

This is just my first shot at the implementation so I'll happily take feedback, or we can close this PR if this functionality it better served in a custom polling strategy rather than a patch to `StrictPriority`. The biggest implementation design question I have right now is what the best way would be to pass the `interval` value into `StrictPriority`? Right now I have it being passed through similarly to `delay` but I'm not sure if it makes sense to bloat classes with arbitrary configuration options. Let me know if you have any thoughts on this.

Closes #535 