### PR TITLE
🔊  Add better logging when loading the Shoryuken environment

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -159,9 +159,15 @@ module Shoryuken
 
       return if non_existent_queues.none?
 
+      error_msg = <<~MSG
+        "The specified queue(s) #{non_existent_queues.join(', ')} do not exist.
+         Try 'shoryuken sqs create QUEUE-NAME' for creating a queue with default settings.
+         It's also possible that you don't have permission to access the specified queues."
+      MSG
+
       fail(
         ArgumentError,
-        "The specified queue(s) #{non_existent_queues.join(', ')} do not exist.\nTry 'shoryuken sqs create QUEUE-NAME' for creating a queue with default settings"
+        error_msg
       )
     end
 

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -159,7 +159,7 @@ module Shoryuken
 
       return if non_existent_queues.none?
 
-      error_msg = <<~MSG
+      error_msg = <<-MSG
         "The specified queue(s) #{non_existent_queues.join(', ')} do not exist.
          Try 'shoryuken sqs create QUEUE-NAME' for creating a queue with default settings.
          It's also possible that you don't have permission to access the specified queues."

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -159,10 +159,12 @@ module Shoryuken
 
       return if non_existent_queues.none?
 
-      error_msg = <<-MSG
-        "The specified queue(s) #{non_existent_queues.join(', ')} do not exist.
-         Try 'shoryuken sqs create QUEUE-NAME' for creating a queue with default settings.
-         It's also possible that you don't have permission to access the specified queues."
+      # NOTE: HEREDOC's ~ operator removes indents, but is only available Ruby 2.3+
+      # See github PR: https://github.com/ruby-shoryuken/shoryuken/pull/691#issuecomment-1007653595
+      error_msg = <<-MSG.gsub(/^\s+/, '')
+        The specified queue(s) #{non_existent_queues.join(', ')} do not exist.
+        Try 'shoryuken sqs create QUEUE-NAME' for creating a queue with default settings.
+        It's also possible that you don't have permission to access the specified queues.
       MSG
 
       fail(

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Shoryuken::EnvironmentLoader do
     end
   end
 
-
   describe '#prefix_active_job_queue_names' do
     before do
       allow(subject).to receive(:load_rails)
@@ -94,6 +93,7 @@ RSpec.describe Shoryuken::EnvironmentLoader do
       expect(Shoryuken.groups['group1'][:queues]).to(eq(['arn:aws:sqs:fake-region-1:1234:test_group1_queue1']))
     end
   end
+
   describe "#setup_options" do
     let (:cli_queues) { { "queue1"=> 10, "queue2" => 20 } }
     let (:config_queues) { [["queue1", 8], ["queue2", 4]] }


### PR DESCRIPTION
### Context

When running shoryuken, we ran into an issue where the queue didn't exist. In theory this is true because we don't have permission to access the queue, but the suggestion to create a queue was a bit mis-leading.

More of a suggestion if anything since I noticed we were struggling and maybe it could help others as well! Ultimately the solution was stumbled upon in a [SO post](https://stackoverflow.com/questions/49191868/awssqserrorsnonexistentqueue-the-specified-queue-default-does-not-exist) and some prior knowledge / experience.

Issue link: https://github.com/ruby-shoryuken/shoryuken/issues/692