### PR TITLE
✨  Add custom polling strategy configuration

### DIFF
--- a/lib/shoryuken/logging.rb
+++ b/lib/shoryuken/logging.rb
@@ -34,7 +34,7 @@ module Shoryuken
     end
 
     def self.logger=(log)
-      @logger = (log ? log : Logger.new('/dev/null'))
+      @logger = (log || Logger.new('/dev/null'))
     end
   end
 end

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -57,7 +57,12 @@ module Shoryuken
     end
 
     def polling_strategy(group)
-      strategy = (group == 'default' ? options : options[:groups].to_h[group]).to_h[:polling_strategy]
+      strategy = if group == 'default'
+                   options[:polling_strategy]
+                 else
+                   options[:groups].to_h[group].to_h[:polling_strategy]
+                 end
+
       case strategy
       when 'WeightedRoundRobin', nil # Default case
         Polling::WeightedRoundRobin

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -69,7 +69,6 @@ module Shoryuken
 
       return Polling::WeightedRoundRobin if strategy.nil?
 
-      # check if error is raised, otherwise just return
       begin
         case strategy
         when String

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -63,8 +63,10 @@ module Shoryuken
                    options[:groups].to_h[group].to_h[:polling_strategy]
                  end
 
+      return Polling::WeightedRoundRobin if strategy.nil?
+
       case strategy
-      when 'WeightedRoundRobin', nil # Default case
+      when 'WeightedRoundRobin' # Default case
         Polling::WeightedRoundRobin
       when 'StrictPriority'
         Polling::StrictPriority

--- a/spec/shoryuken/options_spec.rb
+++ b/spec/shoryuken/options_spec.rb
@@ -196,18 +196,22 @@ RSpec.describe Shoryuken::Options do
     context 'when providing a custom strategy' do
       before do
         class CustomStrategy < Shoryuken::Polling::BaseStrategy; end
+        module Custom
+          class Strategy
+          end
+        end
 
         Shoryuken.options[:polling_strategy] = 'CustomStrategy'
         Shoryuken.options[:groups] = {
           'group1' => {
-            polling_strategy: 'CustomStrategy'
+            polling_strategy: 'Custom::Strategy'
           }
         }
       end
 
       specify do
         expect(Shoryuken.polling_strategy('default')).to eq CustomStrategy
-        expect(Shoryuken.polling_strategy('group1')).to eq CustomStrategy
+        expect(Shoryuken.polling_strategy('group1')).to eq Custom::Strategy
       end
     end
 

--- a/spec/shoryuken/options_spec.rb
+++ b/spec/shoryuken/options_spec.rb
@@ -193,6 +193,24 @@ RSpec.describe Shoryuken::Options do
       end
     end
 
+    context 'when providing a custom strategy' do
+      before do
+        class CustomStrategy < Shoryuken::Polling::BaseStrategy; end
+
+        Shoryuken.options[:polling_strategy] = 'CustomStrategy'
+        Shoryuken.options[:groups] = {
+          'group1' => {
+            polling_strategy: 'CustomStrategy'
+          }
+        }
+      end
+
+      specify do
+        expect(Shoryuken.polling_strategy('default')).to eq CustomStrategy
+        expect(Shoryuken.polling_strategy('group1')).to eq CustomStrategy
+      end
+    end
+
     context 'when set to a class' do
       before do
         class Foo < Shoryuken::Polling::BaseStrategy; end


### PR DESCRIPTION
### What

I was reading through an issue because I was curious (https://github.com/ruby-shoryuken/shoryuken/issues/675) and thought it could be fun to tackle. That said, if I am off track, please let me know.

This PR _should_ add the ability to define custom polling strategies in `.yml`s using `Object#const_get`. To be honest, it's my first time using it, so if there are better ways -- happy to correct.

I also cleaned up a bit of code, but am happy to revert any refactoring changes if needed.

Gitmoji ref: https://gitmoji.dev/