### PR TITLE
Fix for ActiveSupport::CurrentAttributes resetting issue

### DIFF
--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -15,10 +15,11 @@ module Shoryuken
 
     def process
       return logger.error { "No worker found for #{queue}" } unless worker
-
-      Shoryuken::Logging.with_context("#{worker_name(worker.class, sqs_msg, body)}/#{queue}/#{sqs_msg.message_id}") do
-        worker.class.server_middleware.invoke(worker, queue, sqs_msg, body) do
-          worker.perform(sqs_msg, body)
+      ::Rails.application.reloader.wrap do
+        Shoryuken::Logging.with_context("#{worker_name(worker.class, sqs_msg, body)}/#{queue}/#{sqs_msg.message_id}") do
+          worker.class.server_middleware.invoke(worker, queue, sqs_msg, body) do
+            worker.perform(sqs_msg, body)
+          end
         end
       end
     rescue Exception => ex


### PR DESCRIPTION
- Wrap processor's process code around rails reloader to prevent resetting of current attributes after they are assigned in server middleware
- Linked to issue #719 