### PR TITLE
Add default body value to worker perform methods

### DIFF
--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -6,11 +6,11 @@ module Shoryuken
     end
 
     module ClassMethods
-      def perform_async(body, options = {})
+      def perform_async(body = ' ', options = {})
         Shoryuken.worker_executor.perform_async(self, body, options)
       end
 
-      def perform_in(interval, body, options = {})
+      def perform_in(interval, body = ' ', options = {})
         Shoryuken.worker_executor.perform_in(self, interval, body, options)
       end
 

--- a/spec/shoryuken/worker/inline_executor_spec.rb
+++ b/spec/shoryuken/worker/inline_executor_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe Shoryuken::Worker::InlineExecutor do
     end
   end
 
+  context 'without arguments' do
+    describe '.perform_async' do
+      specify do
+        expect_any_instance_of(TestWorker).to receive(:perform).with(anything, ' ')
+
+        TestWorker.perform_async
+      end
+    end
+
+    describe '.perform_in' do
+      specify do
+        expect_any_instance_of(TestWorker).to receive(:perform).with(anything, ' ')
+
+        TestWorker.perform_in(60)
+      end
+    end
+  end
+
   context 'batch' do
     before do
       TestWorker.get_shoryuken_options['batch'] = true


### PR DESCRIPTION
### Context
Recently, I’ve been working on a new shoryuken worker and this particulary one does not require an argument to be scheduled and executed. 

For this scenario, the solution was give a empty string as the argument, since the body argument it’s required, something like this:

```ruby
class Job
  include Shoryuken::Worker
	
  shoryuken_options queue: "queue-name", auto_delete: true

  def perform(_message, _body)
  end
end

Job.perform_async(" ")
```

### Suggestion
The idea with this PR is turn the body argument into optional, passing a string with a blank space as the default value, because it’s not possible to send a message without body, according to the aws sqs client ([link](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SQS/Client.html#send_message-instance_method)).

With the changes, workers could be called like:
```ruby
class Job
  include Shoryuken::Worker
	
  shoryuken_options queue: "queue-name", auto_delete: true

  def perform(_message, _body)
  end
end

Job.perform_async
```
Let me know if this makes sense, happy to close if not!