### PR TITLE
fetch default group options if options is not set by group nor queue

### DIFF
--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -76,6 +76,7 @@ module Shoryuken
     def receive_options(queue)
       options = Shoryuken.sqs_client_receive_message_opts[queue.name]
       options ||= Shoryuken.sqs_client_receive_message_opts[@group]
+      options ||= Shoryuken.sqs_client_receive_message_opts['default']
 
       options.to_h.dup
     end


### PR DESCRIPTION
fixes https://github.com/ruby-shoryuken/shoryuken/issues/735

This is a breaking change if `sqs_client_receive_message_opts` is set for the 'default' group, but not set for the 'non-default' group