### PR TITLE
fire stopped event after executor is stopped

### DIFF
--- a/lib/shoryuken/launcher.rb
+++ b/lib/shoryuken/launcher.rb
@@ -17,10 +17,9 @@ module Shoryuken
       initiate_stop
 
       executor.shutdown
+      executor.kill unless executor.wait_for_termination(Shoryuken.options[:timeout])
 
-      return if executor.wait_for_termination(Shoryuken.options[:timeout])
-
-      executor.kill
+      fire_event(:stopped)
     end
 
     def stop
@@ -33,6 +32,8 @@ module Shoryuken
 
       executor.shutdown
       executor.wait_for_termination
+
+      fire_event(:stopped)
     end
 
     def healthy?

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -11,7 +11,8 @@ module Shoryuken
         dispatch: [],
         utilization_update: [],
         quiet: [],
-        shutdown: []
+        shutdown: [],
+        stopped: []
       }
     }.freeze
 
@@ -134,7 +135,7 @@ module Shoryuken
     end
 
     # Register a block to run at a point in the Shoryuken lifecycle.
-    # :startup, :quiet or :shutdown are valid events.
+    # :startup, :quiet, :shutdown or :stopped are valid events.
     #
     #   Shoryuken.configure_server do |config|
     #     config.on(:shutdown) do

--- a/spec/shoryuken/launcher_spec.rb
+++ b/spec/shoryuken/launcher_spec.rb
@@ -57,4 +57,35 @@ RSpec.describe Shoryuken::Launcher do
       end
     end
   end
+
+  describe '#stop' do
+    before do
+      allow(first_group_manager).to receive(:stop_new_dispatching)
+      allow(first_group_manager).to receive(:await_dispatching_in_progress)
+      allow(second_group_manager).to receive(:stop_new_dispatching)
+      allow(second_group_manager).to receive(:await_dispatching_in_progress)
+    end
+
+    it 'fires quiet, shutdown and stopped event' do
+      expect(subject).to receive(:fire_event).with(:quiet, true)
+      expect(subject).to receive(:fire_event).with(:shutdown, true)
+      expect(subject).to receive(:fire_event).with(:stopped)
+      subject.stop
+    end
+  end
+
+  describe '#stop!' do
+    before do
+      allow(first_group_manager).to receive(:stop_new_dispatching)
+      allow(first_group_manager).to receive(:await_dispatching_in_progress)
+      allow(second_group_manager).to receive(:stop_new_dispatching)
+      allow(second_group_manager).to receive(:await_dispatching_in_progress)
+    end
+
+    it 'fires shutdown and stopped event' do
+      expect(subject).to receive(:fire_event).with(:shutdown, true)
+      expect(subject).to receive(:fire_event).with(:stopped)
+      subject.stop!
+    end
+  end
 end


### PR DESCRIPTION
adds a new event "stopped" after stopping the executor.

closes https://github.com/ruby-shoryuken/shoryuken/issues/740