### PR TITLE
Adds nullish coalescing to output of Aws::SQS::Client#receive_message to an empty array

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,10 @@ gemspec
 group :test do
   gem 'activejob'
   gem 'aws-sdk-core', '~> 3'
-  gem 'aws-sdk-sqs'
+  # Pin to 1.65.0 because of below issues:
+  # - https://github.com/ruby-shoryuken/shoryuken/pull/753#issuecomment-1822720647
+  # - https://github.com/getmoto/moto/issues/7054
+  gem 'aws-sdk-sqs', '1.65.0'
   gem 'codeclimate-test-reporter', require: nil
   gem 'httparty'
   gem 'multi_xml'

--- a/bin/cli/sqs.rb
+++ b/bin/cli/sqs.rb
@@ -117,7 +117,7 @@ module Shoryuken
               max_number_of_messages: batch_size,
               attribute_names: ['All'],
               message_attribute_names: ['All']
-            ).messages
+            ).messages || []
 
             messages.each { |m| yield m }
 

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -43,7 +43,8 @@ module Shoryuken
     end
 
     def receive_messages(options)
-      client.receive_message(options.merge(queue_url: url)).messages.map { |m| Message.new(client, self, m) }
+      messages = client.receive_message(options.merge(queue_url: url)).messages || []
+      messages.map { |m| Message.new(client, self, m) }
     end
 
     def fifo?


### PR DESCRIPTION
Fixes #752 due to change in behavior of `aws-sdk-sqs` (https://github.com/aws/aws-sdk-ruby/issues/2947)

- This adds a default value of `[]` to all invocations of `Aws::SQS::Client#receive_message`
- The underlying behavior in the AWS Ruby SDK appears to have been patched, but this will prevent regressions in the future should something similar happen again