### PR TITLE
delete_message_batch failed is returning nil rather than empty array …

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -21,9 +21,10 @@ module Shoryuken
     end
 
     def delete_messages(options)
-      client.delete_message_batch(
+      failed_messages = client.delete_message_batch(
         options.merge(queue_url: url)
-      ).failed.any? do |failure|
+      ).failed || []
+      failed_messages.any? do |failure|
         logger.error do
           "Could not delete #{failure.id}, code: '#{failure.code}', message: '#{failure.message}', sender_fault: #{failure.sender_fault}"
         end


### PR DESCRIPTION
…as before, default to empty array if nil returned.

I am seeing errors for `Shoryuken::Queue#delete_messages`
```
Processor failed: undefined method `any?' for nil:NilClass
ERROR: lib/shoryuken/queue.rb:26:in `delete_messages'
```

This simply defaults to an empty array if nil is returned for failed_messages.

Similar fix to #753 