### PR TITLE
Fix activerecord 7.1 deprecation warnings

### DIFF
--- a/lib/shoryuken/middleware/server/active_record.rb
+++ b/lib/shoryuken/middleware/server/active_record.rb
@@ -5,7 +5,7 @@ module Shoryuken
         def call(*_args)
           yield
         ensure
-          ::ActiveRecord::Base.clear_active_connections!
+          ::ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
         end
       end
     end

--- a/lib/shoryuken/middleware/server/active_record.rb
+++ b/lib/shoryuken/middleware/server/active_record.rb
@@ -5,7 +5,11 @@ module Shoryuken
         def call(*_args)
           yield
         ensure
-          ::ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+          if ::ActiveRecord.version >= Gem::Version.new('7.1')
+            ::ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+          else
+            ::ActiveRecord::Base.clear_active_connections!
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes the following:

<code>DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler; for example: `ActiveRecord::Base.connection_handler.clear_active_connections!`. (called from call at /app/.bundle/ruby/3.2.0/bundler/gems/shoryuken-869fb0c77f8e/lib/shoryuken/middleware/server/active_record.rb:8)</code>

<code>DEPRECATION WARNING: `clear_active_connections!` currently only applies to connection pools in the current role (`writing`). In Rails 7.2, this method will apply to all known pools, regardless of role. To affect only those connections belonging to a specific role, pass the role name as an argument. To switch to the new behavior, pass `:all` as the role name. (called from call at /app/.bundle/ruby/3.2.0/bundler/gems/shoryuken-869fb0c77f8e/lib/shoryuken/middleware/server/active_record.rb:8)</code>