### PR TITLE
Scope the shoryuken context to the current fiber.

### DIFF
--- a/lib/shoryuken/logging.rb
+++ b/lib/shoryuken/logging.rb
@@ -1,6 +1,10 @@
 require 'time'
 require 'logger'
 
+class Fiber
+  attr_accessor :shoryuken_context
+end
+
 module Shoryuken
   module Logging
     class Pretty < Logger::Formatter
@@ -10,16 +14,15 @@ module Shoryuken
       end
 
       def context
-        c = Thread.current[:shoryuken_context]
-        c ? " #{c}" : ''
+        Fiber.current.shoryuken_context&.then{|context| " #{context}"}
       end
     end
 
     def self.with_context(msg)
-      Thread.current[:shoryuken_context] = msg
+      Fiber.current.shoryuken_context = msg
       yield
     ensure
-      Thread.current[:shoryuken_context] = nil
+      Fiber.current.shoryuken_context = nil
     end
 
     def self.initialize_logger(log_target = STDOUT)


### PR DESCRIPTION
I'd like to start a discussion about how to more efficiently manage the context during logging.

This exposes a proper interface for getting the current context.

In addition, I'd like to understand, do you expect if someone creates child fibers or threads, that the context should be shared? e.g. map-reduce / fan-out style workloads. I'm assuming the answer should be yes, but I'd like to know your opinion. In that case, it's better to use `Fiber#storage`.