### PR TITLE
Add the Ability to be Able to Configure the Logger

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -78,6 +78,7 @@ module Shoryuken
     :exception_handlers=,
     :options,
     :logger,
+    :logger=,
     :register_worker,
     :configure_server,
     :server?,

--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -14,7 +14,7 @@ module ActiveJob
     # To use Shoryuken set the queue_adapter config to +:shoryuken+.
     #
     #   Rails.application.config.active_job.queue_adapter = :shoryuken
-    class ShoryukenAdapter
+    class ShoryukenAdapter < ActiveJob::QueueAdapters::AbstractAdapter
       class << self
         def instance
           # https://github.com/phstc/shoryuken/pull/174#issuecomment-174555657

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -16,10 +16,12 @@ module Shoryuken
       }
     }.freeze
 
-    attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout, :groups,
-                  :launcher_executor, :reloader, :enable_reloading,
-                  :start_callback, :stop_callback, :worker_executor, :worker_registry, :exception_handlers
-    attr_writer :default_worker_options, :sqs_client
+    attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout,
+      :groups, :launcher_executor, :reloader, :enable_reloading,
+      :start_callback, :stop_callback, :worker_executor, :worker_registry,
+      :exception_handlers
+
+    attr_writer :default_worker_options, :sqs_client, :logger
     attr_reader :sqs_client_receive_message_opts
 
     def initialize
@@ -95,7 +97,7 @@ module Shoryuken
     end
 
     def logger
-      Shoryuken::Logging.logger
+      @logger ||= Shoryuken::Logging.logger
     end
 
     def register_worker(*args)


### PR DESCRIPTION
This PR allows Shoryuken to be able to configure the logger such as:

```ruby
Shoryuken.logger = Appsignal::Logger.new('shoryuken')
Shoryuken.logger.formatter = Shoryuken::Logging::WithoutTimestamp.new
```

This provides some feature parity to Sidekiq and helps developers that are using a service like AppSignal get their logs up there.

https://docs.appsignal.com/logging/platforms/integrations/ruby.html#sidekiq-logger