### PR TITLE
Fix typo in README: change 'interested on' to 'interested in'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**I'm looking for Shoryuken maintainers, are you interested on helping to maintain Shoryuken? [Join our Slack](https://join.slack.com/t/shoryuken/shared_invite/zt-19xjq3iqc-KmoJ6eU6~qvZNqcLzIrjww)**
+**I'm looking for Shoryuken maintainers, are you interested in helping to maintain Shoryuken? [Join our Slack](https://join.slack.com/t/shoryuken/shared_invite/zt-19xjq3iqc-KmoJ6eU6~qvZNqcLzIrjww)**
 
 # Shoryuken
 


### PR DESCRIPTION
Corrected a grammatical error in the README where 'interested on' was used instead of 'interested in'. This change improves the readability and accuracy of the documentation.
