### PR TITLE
Fix integration tests by updating aws-sdk-sqs and replacing moto with LocalStack

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -13,10 +13,17 @@ jobs:
         gemfile: ['Gemfile', 'gemfiles/aws_sdk_core_2.gemfile']
     runs-on: ubuntu-20.04
     services:
-      moto_sqs:
-        image: quay.io/cjlarose/moto-sqs-server:1.1.0
-        ports:
-          - 5000:5000
+      localstack:
+      image: localstack/localstack:latest
+      environment:
+        - SERVICES=sqs
+      ports:
+        - 4566:4566
+      healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+        interval: 5s
+        timeout: 10s
+        retries: 5
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -15,15 +15,15 @@ jobs:
     services:
       localstack:
         image: localstack/localstack:latest
-        environment:
-          - SERVICES=sqs
+        env:
+          SERVICES: sqs
         ports:
           - 4566:4566
-        healthcheck:
-          test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
-          interval: 5s
-          timeout: 10s
-          retries: 5
+        options: >-
+          --healthcheck-cmd "curl -f http://localhost:4566/_localstack/health"
+          --healthcheck-interval 5s
+          --healthcheck-timeout 10s
+          --healthcheck-retries 5
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,6 @@ gemspec
 group :test do
   gem 'activejob'
   gem 'aws-sdk-core', '~> 3'
-  # Pin to 1.65.0 because of below issues:
-  # - https://github.com/ruby-shoryuken/shoryuken/pull/753#issuecomment-1822720647
-  # - https://github.com/getmoto/moto/issues/7054
   gem 'aws-sdk-sqs'
   gem 'codeclimate-test-reporter', require: nil
   gem 'httparty'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :test do
   # Pin to 1.65.0 because of below issues:
   # - https://github.com/ruby-shoryuken/shoryuken/pull/753#issuecomment-1822720647
   # - https://github.com/getmoto/moto/issues/7054
-  gem 'aws-sdk-sqs', '1.65.0'
+  gem 'aws-sdk-sqs'
   gem 'codeclimate-test-reporter', require: nil
   gem 'httparty'
   gem 'multi_xml'

--- a/gemfiles/aws_sdk_core_2.gemfile
+++ b/gemfiles/aws_sdk_core_2.gemfile
@@ -8,6 +8,7 @@ group :test do
   gem "codeclimate-test-reporter", require: nil
   gem "httparty"
   gem "multi_xml"
+  gem "nokogiri"
   gem "simplecov"
   gem "webrick"
 end

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Shoryuken::Launcher do
   let(:sqs_client) do
     Aws::SQS::Client.new(
       region: 'us-east-1',
-      endpoint: 'http://localhost:5000',
+      endpoint: 'http://localhost:4566',
       access_key_id: 'fake',
       secret_access_key: 'fake'
     )
@@ -52,6 +52,12 @@ RSpec.describe Shoryuken::Launcher do
 
     after do
       Aws.config[:stub_responses] = true
+
+      queue_url = Shoryuken::Client.sqs.get_queue_url(
+        queue_name: StandardWorker.get_shoryuken_options['queue']
+      ).queue_url
+
+      Shoryuken::Client.sqs.delete_queue(queue_url: queue_url)
     end
 
     it 'consumes as a command worker' do

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -52,12 +52,6 @@ RSpec.describe Shoryuken::Launcher do
 
     after do
       Aws.config[:stub_responses] = true
-
-      queue_url = Shoryuken::Client.sqs.get_queue_url(
-        queue_name: StandardWorker.get_shoryuken_options['queue']
-      ).queue_url
-
-      Shoryuken::Client.sqs.delete_queue(queue_url: queue_url)
     end
 
     it 'consumes as a command worker' do

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -94,11 +94,13 @@ RSpec.describe Shoryuken::Launcher do
     end
 
     def poll_queues_until
+      retries = 0
       subject.start
 
-      Timeout::timeout(10) do
+      Timeout::timeout(30) do
         begin
-          sleep 0.5
+          sleep 0.5 * (retries + 1)
+          retries += 1
         end until yield
       end
     ensure

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -94,13 +94,11 @@ RSpec.describe Shoryuken::Launcher do
     end
 
     def poll_queues_until
-      retries = 0
       subject.start
 
-      Timeout::timeout(30) do
+      Timeout::timeout(10) do
         begin
-          sleep 0.5 * (retries + 1)
-          retries += 1
+          sleep 0.5
         end until yield
       end
     ensure


### PR DESCRIPTION
This PR replaces moto with LocalStack for integration testing. Changes include:

1. Updates aws-sdk-sqs to latest version
2. Adds docker-compose configuration for LocalStack
3. Updates integration tests to use LocalStack

Background:
Currently, aws-sdk-sqs is pinned to v1.65.0 due to moto compatibility issues. The mock service returns XML responses while aws-sdk-sqs expects JSON, causing parse errors. 

After experimenting with LocalStack, it proved to handle the AWS SDK responses correctly, allowing us to:
- Use the latest aws-sdk-sqs version
- Remove version constraints
- Have a more AWS-like testing environment

What do you think about this approach?

Related to #781