### PR TITLE
cleanup require flow

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -1,11 +1,6 @@
 require 'yaml'
 require 'json'
-require 'aws-sdk-core'
-begin
-  require 'aws-sdk-sqs' unless defined?(Aws::SQS)
-rescue LoadError
-  fail "AWS SDK 3 requires aws-sdk-sqs to be installed separately. Please add gem 'aws-sdk-sqs' to your Gemfile"
-end
+require 'aws-sdk-sqs'
 require 'time'
 require 'concurrent'
 require 'forwardable'


### PR DESCRIPTION
Since now we do require `sqs` there is no point in optional require flow. This PR fixes that.