### PR TITLE
drop ruby 2.7 and require minimum of Ruby 3.0 in gemspec

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -9,7 +9,7 @@ jobs:
     name: All Specs
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
         gemfile: ['Gemfile']
     runs-on: ubuntu-24.04
     services:

--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-sqs', '>= 1.66.0'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'thor'
+
+  spec.required_ruby_version = '>= 3.0.0'
 end


### PR DESCRIPTION
close https://github.com/ruby-shoryuken/shoryuken/issues/788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated compatibility requirements so the system now supports Ruby versions 3.0.0 and above.
  - Adjusted the testing workflow to focus solely on supported Ruby versions, streamlining quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->