### PR TITLE
remove dependabot since renovate is on

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
renovate already covers this and more so no need to keep dependabot running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the scheduled automated updates for dependency management related to GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->