### PR TITLE
[Chore] Add Support for message_attributes to InlineExecutor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,11 @@ AllCops:
     - '**/Gemfile'
   TargetRubyVersion: 3.4
 
+Metrics/BlockLength:
+  AllowedMethods:
+    - describe
+    - context
+
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/lib/shoryuken/worker/inline_executor.rb
+++ b/lib/shoryuken/worker/inline_executor.rb
@@ -5,13 +5,18 @@ module Shoryuken
         def perform_async(worker_class, body, options = {})
           body = JSON.dump(body) if body.is_a?(Hash)
           queue_name = options.delete(:queue) || worker_class.get_shoryuken_options['queue']
+          message_attributes = options.delete(:message_attributes) || {}
+          message_attributes['shoryuken_class'] = {
+            string_value: worker_class.to_s,
+            data_type: 'String'
+          }
 
           sqs_msg = OpenStruct.new(
             body: body,
             attributes: nil,
             md5_of_body: nil,
             md5_of_message_attributes: nil,
-            message_attributes: nil,
+            message_attributes: message_attributes,
             message_id: nil,
             receipt_handle: nil,
             delete: nil,

--- a/spec/shoryuken/worker/inline_executor_spec.rb
+++ b/spec/shoryuken/worker/inline_executor_spec.rb
@@ -11,6 +11,20 @@ RSpec.describe Shoryuken::Worker::InlineExecutor do
 
       TestWorker.perform_async('test')
     end
+
+    it 'properly sets message_attributes' do
+      custom_attributes = {
+        'custom_key' => { string_value: 'custom_value', data_type: 'String' }
+      }
+
+      expect_any_instance_of(TestWorker).to receive(:perform) do |_, sqs_msg, _|
+        expect(sqs_msg.message_attributes).to include('shoryuken_class')
+        expect(sqs_msg.message_attributes).to include('custom_key')
+        expect(sqs_msg.message_attributes['custom_key'][:string_value]).to eq('custom_value')
+      end
+
+      TestWorker.perform_async('test', message_attributes: custom_attributes)
+    end
   end
 
   describe '.perform_in' do
@@ -18,6 +32,20 @@ RSpec.describe Shoryuken::Worker::InlineExecutor do
       expect_any_instance_of(TestWorker).to receive(:perform).with(anything, 'test')
 
       TestWorker.perform_in(60, 'test')
+    end
+
+    it 'properly passes message_attributes to perform_async' do
+      custom_attributes = {
+        'custom_key' => { string_value: 'custom_value', data_type: 'String' }
+      }
+
+      expect_any_instance_of(TestWorker).to receive(:perform) do |_, sqs_msg, _|
+        expect(sqs_msg.message_attributes).to include('shoryuken_class')
+        expect(sqs_msg.message_attributes).to include('custom_key')
+        expect(sqs_msg.message_attributes['custom_key'][:string_value]).to eq('custom_value')
+      end
+
+      TestWorker.perform_in(60, 'test', message_attributes: custom_attributes)
     end
   end
 


### PR DESCRIPTION
- **chore: add support for message_attributes to InlineExecutor**
- **chore: disable Metrics/BlockLength rule for RSpec describe and context blocks**
