### PR TITLE
Configure server side logging

### DIFF
--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -11,7 +11,7 @@ end
 
 group :development do
   gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
-  gem "pry-byebug", "3.9.0"
+  gem "pry-byebug"
   gem "rubocop"
 end
 

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -11,9 +11,8 @@ end
 
 group :development do
   gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
+  gem "pry-byebug"
   gem "rubocop"
-  gem "pry", ">= 0.14.2"
-  gem "pry-byebug", ">= 3.10.1"
 end
 
 gemspec path: "../"

--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -75,6 +75,7 @@ module Shoryuken
     :exception_handlers=,
     :options,
     :logger,
+    :logger=,
     :register_worker,
     :configure_server,
     :server?,

--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -2,11 +2,10 @@
 # Example adapters ref: https://github.com/rails/rails/tree/master/activejob/lib/active_job/queue_adapters
 
 require 'shoryuken'
-require 'active_job/queue_adapters/abstract_adapter'
 
 module ActiveJob
   module QueueAdapters
-    if ActiveJob.version > Gem::Version.new("6.1.0")
+    if ActiveJob.version >= Gem::Version.new("7.0.0")
       class BaseAdapter < ActiveJob::QueueAdapters::AbstractAdapter; end
     else
       class BaseAdapter; end

--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -6,6 +6,12 @@ require 'active_job/queue_adapters/abstract_adapter'
 
 module ActiveJob
   module QueueAdapters
+    if Gem::Version.new(Rails.version) > Gem::Version.new("6.1.0")
+      class BaseAdapter < ActiveJob::QueueAdapters::AbstractAdapter; end
+    else
+      class BaseAdapter; end
+    end
+
     # == Shoryuken adapter for Active Job
     #
     # Shoryuken ("sho-ryu-ken") is a super-efficient AWS SQS thread based message processor.
@@ -15,7 +21,7 @@ module ActiveJob
     # To use Shoryuken set the queue_adapter config to +:shoryuken+.
     #
     #   Rails.application.config.active_job.queue_adapter = :shoryuken
-    class ShoryukenAdapter < ActiveJob::QueueAdapters::AbstractAdapter
+    class ShoryukenAdapter < BaseAdapter
       class << self
         def instance
           # https://github.com/phstc/shoryuken/pull/174#issuecomment-174555657

--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -14,7 +14,7 @@ module ActiveJob
     # To use Shoryuken set the queue_adapter config to +:shoryuken+.
     #
     #   Rails.application.config.active_job.queue_adapter = :shoryuken
-    class ShoryukenAdapter
+    class ShoryukenAdapter < ActiveJob::QueueAdapters::AbstractAdapter
       class << self
         def instance
           # https://github.com/phstc/shoryuken/pull/174#issuecomment-174555657

--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -2,6 +2,7 @@
 # Example adapters ref: https://github.com/rails/rails/tree/master/activejob/lib/active_job/queue_adapters
 
 require 'shoryuken'
+require 'active_job/queue_adapters/abstract_adapter'
 
 module ActiveJob
   module QueueAdapters

--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -6,7 +6,7 @@ require 'active_job/queue_adapters/abstract_adapter'
 
 module ActiveJob
   module QueueAdapters
-    if Gem::Version.new(Rails.version) > Gem::Version.new("6.1.0")
+    if ActiveJob.version > Gem::Version.new("6.1.0")
       class BaseAdapter < ActiveJob::QueueAdapters::AbstractAdapter; end
     else
       class BaseAdapter; end

--- a/lib/shoryuken/logging.rb
+++ b/lib/shoryuken/logging.rb
@@ -5,7 +5,7 @@ module Shoryuken
   module Logging
     class Base < ::Logger::Formatter
       def tid
-        Thread.current["sidekiq_tid"] ||= (Thread.current.object_id ^ ::Process.pid).to_s(36)
+        Thread.current['shoryuken_tid'] ||= (Thread.current.object_id ^ ::Process.pid).to_s(36)
       end
 
       def context

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -17,10 +17,12 @@ module Shoryuken
       }
     }.freeze
 
-    attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout, :groups,
-                  :launcher_executor, :reloader, :enable_reloading,
-                  :start_callback, :stop_callback, :worker_executor, :worker_registry, :exception_handlers
-    attr_writer :default_worker_options, :sqs_client
+    attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout,
+      :groups, :launcher_executor, :reloader, :enable_reloading,
+      :start_callback, :stop_callback, :worker_executor, :worker_registry,
+      :exception_handlers
+
+    attr_writer :default_worker_options, :sqs_client, :logger
     attr_reader :sqs_client_receive_message_opts
 
     def initialize
@@ -96,7 +98,7 @@ module Shoryuken
     end
 
     def logger
-      Shoryuken::Logging.logger
+      @logger ||= Shoryuken::Logging.logger
     end
 
     def thread_priority

--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 
+  spec.add_dependency 'mutex_m'
   spec.add_dependency 'aws-sdk-sqs', '>= 1.66.0'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'thor'


### PR DESCRIPTION
This PR allows Shoryuken to be able to configure the logger such as:

```ruby
Shoryuken.logger = Appsignal::Logger.new('shoryuken')
Shoryuken.logger.formatter = Shoryuken::Logging::WithoutTimestamp.new
```

This provides some feature parity to Sidekiq and helps developers that are using a service like AppSignal get their logs up there.

https://docs.appsignal.com/logging/platforms/integrations/ruby.html#sidekiq-logger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to set a custom logger through the main interface.
  - Introduced a new log formatter that omits timestamps for log messages.
- **Refactor**
  - Improved logging formatter structure for better code organization and shared functionality.
  - Updated logger handling for improved performance by caching the logger instance.
- **Style**
  - Reformatted attribute declarations for improved readability.
- **Chores**
  - Updated class inheritance for compatibility with external job queue adapters.
  - Updated gem dependencies to allow more flexible version resolution and added a new runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->