### PR TITLE
Change MAX_BATCH_SIZE

### DIFF
--- a/bin/cli/sqs.rb
+++ b/bin/cli/sqs.rb
@@ -5,7 +5,7 @@ module Shoryuken
   module CLI
     class SQS < Base
       # See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
-      MAX_BATCH_SIZE = 256 * 1024
+      MAX_BATCH_SIZE = 1024 * 1024
 
       namespace :sqs
       class_option :endpoint, aliases: '-e', type: :string, default: ENV['SHORYUKEN_SQS_ENDPOINT'], desc: 'Endpoint URL'


### PR DESCRIPTION
> Message Size Limit: The total size of all messages sent in a single SendMessageBatch call cannot exceed 1,048,576 bytes (1 MiB)

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-batch-api-actions.html
https://aws.amazon.com/jp/about-aws/whats-new/2025/08/amazon-sqs-max-payload-size-1mib/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed batch payload size for sending messages to SQS, enabling larger batches to be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->