### PR TITLE
remove mutex_m

### DIFF
--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk-sqs', '>= 1.66.0'
   spec.add_dependency 'concurrent-ruby'
-  spec.add_dependency 'mutex_m'
   spec.add_dependency 'thor'
   spec.add_dependency 'zeitwerk', '~> 2.6'
 

--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -16,15 +16,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'dotenv'
-  spec.add_development_dependency 'ostruct'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-
   spec.add_dependency 'aws-sdk-sqs', '>= 1.66.0'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'thor'
   spec.add_dependency 'zeitwerk', '~> 2.6'
+
+  spec.add_development_dependency 'dotenv'
+  spec.add_development_dependency 'ostruct'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 
   spec.required_ruby_version = '>= 3.1.0'
 end


### PR DESCRIPTION
doesn't seem to be used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unnecessary runtime dependency to streamline installation, reduce the dependency surface, and minimize potential version conflicts.
  * Reorganized development dependency configuration to improve packaging clarity and maintenance.
  * No changes to public APIs or runtime behavior; existing functionality remains unaffected.
  * Users may experience slightly faster installs and fewer transitive packages during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->