### PR TITLE
Replace Concurrent::TimerTask with pure Ruby implementation

### DIFF
--- a/lib/shoryuken/helpers/timer_task.rb
+++ b/lib/shoryuken/helpers/timer_task.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Shoryuken
+  module Helpers
+    # A thread-safe timer task implementation.
+    # Drop-in replacement for Concurrent::TimerTask without external dependencies.
+    class TimerTask
+      def initialize(execution_interval:, &block)
+        @execution_interval = execution_interval
+        @task_block = block
+        @mutex = Mutex.new
+        @thread = nil
+        @running = false
+        @killed = false
+      end
+
+      # Start the timer task execution
+      def execute
+        @mutex.synchronize do
+          return self if @running || @killed
+
+          @running = true
+          @thread = Thread.new { run_timer_loop }
+        end
+        self
+      end
+
+      # Stop and kill the timer task
+      def kill
+        @mutex.synchronize do
+          return false if @killed
+
+          @killed = true
+          @running = false
+
+          if @thread && @thread.alive?
+            @thread.kill
+            @thread.join(1) # Wait up to 1 second for clean shutdown
+          end
+        end
+        true
+      end
+
+      private
+
+      def run_timer_loop
+        while !@killed
+          sleep(@execution_interval)
+          break if @killed
+
+          begin
+            @task_block.call
+          rescue => e
+            # Log the error but continue running
+            # This matches the behavior of Concurrent::TimerTask
+            warn "TimerTask execution error: #{e.message}"
+            warn e.backtrace.join("\n") if e.backtrace
+          end
+        end
+      ensure
+        @mutex.synchronize { @running = false }
+      end
+    end
+  end
+end

--- a/lib/shoryuken/middleware/server/auto_extend_visibility.rb
+++ b/lib/shoryuken/middleware/server/auto_extend_visibility.rb
@@ -30,7 +30,7 @@ module Shoryuken
           def auto_extend(_worker, queue, sqs_msg, _body)
             queue_visibility_timeout = Shoryuken::Client.queues(queue).visibility_timeout
 
-            Concurrent::TimerTask.new(execution_interval: queue_visibility_timeout - EXTEND_UPFRONT_SECONDS) do
+            Shoryuken::Helpers::TimerTask.new(execution_interval: queue_visibility_timeout - EXTEND_UPFRONT_SECONDS) do
               logger.debug do
                 "Extending message #{queue}/#{sqs_msg.message_id} visibility timeout by #{queue_visibility_timeout}s"
               end

--- a/spec/shoryuken/helpers/timer_task_spec.rb
+++ b/spec/shoryuken/helpers/timer_task_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Shoryuken::Helpers::TimerTask do
+  let(:execution_interval) { 0.1 }
+  let(:execution_count) { 0 }
+  let(:timer_task) do
+    described_class.new(execution_interval: execution_interval) do
+      @execution_count = (@execution_count || 0) + 1
+    end
+  end
+
+  describe '#initialize' do
+    it 'creates a timer task with the specified interval' do
+      timer = described_class.new(execution_interval: 5) { }
+      expect(timer).to be_a(described_class)
+    end
+
+    it 'requires a block' do
+      expect { described_class.new(execution_interval: 5) }.to raise_error(LocalJumpError)
+    end
+  end
+
+  describe '#execute' do
+    it 'returns self for method chaining' do
+      result = timer_task.execute
+      expect(result).to eq(timer_task)
+      timer_task.kill
+    end
+
+    it 'does not start multiple times' do
+      timer_task.execute
+      first_thread = timer_task.instance_variable_get(:@thread)
+      timer_task.execute
+      second_thread = timer_task.instance_variable_get(:@thread)
+      expect(first_thread).to eq(second_thread)
+      timer_task.kill
+    end
+  end
+
+  describe '#kill' do
+    it 'returns true when successfully killed' do
+      timer_task.execute
+      expect(timer_task.kill).to be true
+    end
+
+    it 'returns false when already killed' do
+      timer_task.execute
+      timer_task.kill
+      expect(timer_task.kill).to be false
+    end
+
+    it 'is safe to call multiple times' do
+      timer_task.execute
+      expect { timer_task.kill }.not_to raise_error
+      expect { timer_task.kill }.not_to raise_error
+    end
+  end
+
+  describe 'execution behavior' do
+    it 'executes the block at the specified interval' do
+      execution_count = 0
+      timer = described_class.new(execution_interval: 0.05) do
+        execution_count += 1
+      end
+
+      timer.execute
+      sleep(0.15) # Should allow for ~3 executions
+      timer.kill
+
+      expect(execution_count).to be >= 2
+      expect(execution_count).to be <= 4 # Allow some timing variance
+    end
+
+    it 'handles exceptions in the block gracefully' do
+      error_count = 0
+      timer = described_class.new(execution_interval: 0.05) do
+        error_count += 1
+        raise StandardError, "Test error"
+      end
+
+      # Capture stderr to check for error messages
+      original_stderr = $stderr
+      $stderr = StringIO.new
+
+      timer.execute
+      sleep(0.15)
+      timer.kill
+
+      error_output = $stderr.string
+      $stderr = original_stderr
+
+      expect(error_count).to be >= 2
+      expect(error_output).to include("TimerTask execution error: Test error")
+    end
+
+    it 'stops execution when killed' do
+      execution_count = 0
+      timer = described_class.new(execution_interval: 0.05) do
+        execution_count += 1
+      end
+
+      timer.execute
+      sleep(0.1)
+      initial_count = execution_count
+      timer.kill
+      sleep(0.1)
+      final_count = execution_count
+
+      expect(final_count).to eq(initial_count)
+    end
+  end
+
+  describe 'thread safety' do
+    it 'can be safely accessed from multiple threads' do
+      timer = described_class.new(execution_interval: 0.1) { }
+
+      threads = 10.times.map do
+        Thread.new do
+          timer.execute
+          sleep(0.01)
+          timer.kill
+        end
+      end
+
+      threads.each(&:join)
+      # Timer should be stopped after all threads complete
+      expect(timer.instance_variable_get(:@killed)).to be true
+    end
+  end
+end


### PR DESCRIPTION
Replaces Concurrent::TimerTask with a pure Ruby implementation Shoryuken::Helpers::TimerTask to reduce external dependencies on the concurrent-ruby gem.