### PR TITLE
Fix busy-processor counter leak when the executor rejects a worker post

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -181,6 +181,17 @@ module Shoryuken
             processor_done(queue_name)
           end
         end
+    rescue Concurrent::RejectedExecutionError
+      # The executor was shut down (or a bounded custom launcher_executor is
+      # saturated) between the running? check above and the post. The promise
+      # body - and therefore processor_done - never ran, so roll back the
+      # increment here. Leaking it would permanently shrink `ready`
+      # (@max_processors - busy) until dispatch stalls and the group stops
+      # processing. The message was never processed, so we must not run the
+      # FIFO message_processed callback - decrement directly instead.
+      @busy_processors.decrement
+      fire_utilization_update_event
+      nil
     end
 
     # Dispatches a batch of messages from a queue

--- a/spec/lib/shoryuken/manager_spec.rb
+++ b/spec/lib/shoryuken/manager_spec.rb
@@ -222,6 +222,30 @@ RSpec.describe Shoryuken::Manager do
       expect(polling_strategy).to have_received(:message_processed).once
       expect(subject.send(:busy)).to eq(0)
     end
+
+    context 'when the executor rejects the worker post' do
+      # A real ExecutorService instance (Concurrent::Promise validates the
+      # executor type), with running? stubbed true so #assign proceeds past its
+      # guard and post rejecting - exactly the shutdown race / saturated
+      # bounded launcher_executor case. ImmediateExecutor spawns no background
+      # thread, so nothing lingers at teardown.
+      let(:executor) do
+        Concurrent::ImmediateExecutor.new.tap do |rejecting_executor|
+          allow(rejecting_executor).to receive(:running?).and_return(true)
+          allow(rejecting_executor).to receive(:post).and_raise(Concurrent::RejectedExecutionError)
+        end
+      end
+
+      it 'rolls back the busy counter and does not leak it' do
+        # The promise body never runs, so completion must not run either
+        # (decrement directly, and no FIFO message_processed callback).
+        expect(subject).not_to receive(:processor_done)
+
+        expect { subject.send(:assign, queue, sqs_msg) }.not_to raise_error
+
+        expect(subject.send(:busy)).to eq(0)
+      end
+    end
   end
 
   describe '#processor_done' do


### PR DESCRIPTION
Manager#assign increments @busy_processors before posting the worker Promise, but the matching decrement (processor_done) runs *inside* the promise body. When the executor rejects the post
(Concurrent::RejectedExecutionError) - a hard stop racing the running? check, or a saturated bounded custom launcher_executor - the body never runs and the counter leaks. With a bounded executor the leak is permanent: ready (@max_processors - busy) shrinks until dispatch stalls and the group silently stops processing.

Roll back the increment on RejectedExecutionError, decrementing directly (the message was never processed, so the FIFO message_processed callback must not run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when background task execution is rejected.
  * Prevented rejected assignments from leaving processors marked as busy.
  * Ensured rejected tasks do not trigger completion processing or raise unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->