### PR TITLE
Log partial batch-send failures instead of swallowing them

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -89,7 +89,11 @@ module Shoryuken
     # @option options [Array<Hash>] :entries message entries to send
     # @return [Aws::SQS::Types::SendMessageBatchResult] the batch send result
     def send_messages(options)
-      client.send_message_batch(sanitize_messages!(options).merge(queue_url: url))
+      response = client.send_message_batch(sanitize_messages!(options).merge(queue_url: url))
+
+      log_failed_sends(response)
+
+      response
     end
 
     # Receives messages from the queue
@@ -119,6 +123,24 @@ module Shoryuken
     end
 
     private
+
+    # Logs any per-entry failures from a batch send. SQS reports these in
+    # response.failed (throttling, oversize/malformed entries, or a same-batch
+    # duplicate message_deduplication_id) rather than raising, so without this
+    # they are silently swallowed - notably by ShoryukenAdapter#enqueue_all,
+    # which reads only response.successful. Mirrors delete_messages.
+    #
+    # @param response [Aws::SQS::Types::SendMessageBatchResult] the batch result
+    # @return [void]
+    def log_failed_sends(response)
+      return unless response.respond_to?(:failed)
+
+      Array(response.failed).each do |failure|
+        logger.error do
+          "Could not send #{failure.id}, code: '#{failure.code}', message: '#{failure.message}', sender_fault: #{failure.sender_fault}"
+        end
+      end
+    end
 
     # Initializes the FIFO attribute by calling fifo?
     #

--- a/spec/lib/shoryuken/queue_spec.rb
+++ b/spec/lib/shoryuken/queue_spec.rb
@@ -265,6 +265,19 @@ RSpec.describe Shoryuken::Queue do
 
       subject.send_messages(%w[msg1 msg2])
     end
+
+    context 'when some sends fail' do
+      it 'logs each failure (so bulk/enqueue_all drops are not silent)' do
+        failure = double(id: '1', code: 'code', message: '...', sender_fault: false)
+        logger = double('Logger')
+        allow(sqs).to receive(:send_message_batch).and_return(double(failed: [failure]))
+        allow(subject).to receive(:logger).and_return(logger)
+
+        expect(logger).to receive(:error)
+
+        subject.send_messages(entries: [{ id: '0', message_body: 'msg1' }])
+      end
+    end
   end
 
   describe '#fifo?' do


### PR DESCRIPTION
Queue#send_messages returned the SendMessageBatchResult but never looked at response.failed. SQS reports per-entry batch failures there (throttling, oversize/malformed entries, or a same-batch duplicate dedup id) rather than raising, so they vanished silently - most importantly via ShoryukenAdapter#enqueue_all, which reads only response.successful and even marks the dropped jobs successfully_enqueued.

Log each failed entry, mirroring delete_messages. enqueue_all (which calls send_messages) now surfaces them too. The response is still returned unchanged for callers that inspect it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk message sending so failures are now logged instead of being silent.
  * Returned the batch send response after processing, making failure handling more reliable.
* **Tests**
  * Added coverage for partial batch send failures to verify errors are logged correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->